### PR TITLE
Fix router base path normalization and remove BOM

### DIFF
--- a/app/Controllers/MilestoneController.php
+++ b/app/Controllers/MilestoneController.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 declare(strict_types=1);
 

--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -27,11 +27,24 @@ class Router
         $method = strtoupper($method);
         $rawPath = parse_url($uri, PHP_URL_PATH) ?: '/';
 
-        $base = base_url();
-        if ($base !== '' && $base !== '/') {
-            $length = strlen($base);
-            if (strncmp($rawPath, $base, $length) === 0) {
-                $rawPath = substr($rawPath, $length) ?: '/';
+        $baseUrl = base_url();
+        $basePath = '';
+
+        if ($baseUrl !== '') {
+            $basePath = parse_url($baseUrl, PHP_URL_PATH) ?: '';
+            if ($basePath !== '') {
+                $basePath = rtrim($basePath, '/');
+                $basePath = $basePath === '' ? '/' : $basePath;
+            }
+        }
+
+        if ($basePath !== '' && $basePath !== '/') {
+            $length = strlen($basePath);
+            if (strncmp($rawPath, $basePath, $length) === 0) {
+                $nextChar = $rawPath[$length] ?? '';
+                if ($nextChar === '' || $nextChar === '/') {
+                    $rawPath = substr($rawPath, $length) ?: '/';
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- normalize the router base path from `APP_URL` so subdirectory deployments resolve routes correctly
- remove the UTF-8 BOM from `MilestoneController` to avoid premature output when the file is loaded

## Testing
- php -l app/Core/Router.php
- php -l app/Controllers/MilestoneController.php

------
https://chatgpt.com/codex/tasks/task_e_68dad9b41054832eb8b7091aad6fcc27