### PR TITLE
Revamp module UIs for projects, milestones, and progress

### DIFF
--- a/app/Controllers/MilestoneController.php
+++ b/app/Controllers/MilestoneController.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 declare(strict_types=1);
 

--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -27,11 +27,24 @@ class Router
         $method = strtoupper($method);
         $rawPath = parse_url($uri, PHP_URL_PATH) ?: '/';
 
-        $base = base_url();
-        if ($base !== '' && $base !== '/') {
-            $length = strlen($base);
-            if (strncmp($rawPath, $base, $length) === 0) {
-                $rawPath = substr($rawPath, $length) ?: '/';
+        $baseUrl = base_url();
+        $basePath = '';
+
+        if ($baseUrl !== '') {
+            $basePath = parse_url($baseUrl, PHP_URL_PATH) ?: '';
+            if ($basePath !== '') {
+                $basePath = rtrim($basePath, '/');
+                $basePath = $basePath === '' ? '/' : $basePath;
+            }
+        }
+
+        if ($basePath !== '' && $basePath !== '/') {
+            $length = strlen($basePath);
+            if (strncmp($rawPath, $basePath, $length) === 0) {
+                $nextChar = $rawPath[$length] ?? '';
+                if ($nextChar === '' || $nextChar === '/') {
+                    $rawPath = substr($rawPath, $length) ?: '/';
+                }
             }
         }
 

--- a/app/Views/milestones/index.php
+++ b/app/Views/milestones/index.php
@@ -12,6 +12,50 @@ $submissionsByMilestone = $submissionsByMilestone ?? [];
 $usersMap = $usersMap ?? [];
 $feedbackFlash = $feedbackFlash ?? [];
 
+$milestoneStatuses = [
+    'pendiente' => 'Pendiente',
+    'en_progreso' => 'En progreso',
+    'en_revision' => 'En revision',
+    'completado' => 'Completado',
+];
+
+$milestoneStatusStyles = [
+    'pendiente' => 'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200',
+    'en_progreso' => 'bg-sky-100 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200',
+    'en_revision' => 'bg-indigo-100 text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200',
+    'completado' => 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200',
+];
+
+$milestoneTotals = [
+    'pendiente' => 0,
+    'en_progreso' => 0,
+    'en_revision' => 0,
+    'completado' => 0,
+];
+
+$nextDueDate = null;
+
+foreach ($milestones as $milestone) {
+    $status = $milestone['status'] ?? '';
+    if (array_key_exists($status, $milestoneTotals)) {
+        $milestoneTotals[$status] += 1;
+    }
+
+    if (!empty($milestone['due_date'])) {
+        $dueDate = $milestone['due_date'];
+        if ($nextDueDate === null || $dueDate < $nextDueDate) {
+            $nextDueDate = $dueDate;
+        }
+    }
+}
+
+$milestoneProgress = 0;
+if ($milestones !== []) {
+    $total = count($milestones);
+    $completed = $milestoneTotals['completado'] ?? 0;
+    $milestoneProgress = $total > 0 ? round(($completed / $total) * 100) : 0;
+}
+
 ob_start();
 ?>
 <?php if ($statusMessage): ?>
@@ -25,6 +69,33 @@ ob_start();
     Aun no tienes proyectos disponibles. Crea uno primero para poder definir hitos.
   </div>
 <?php else: ?>
+  <section class="mb-5 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+    <article class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <p class="text-xs text-slate-500 dark:text-slate-400">Hitos totales</p>
+      <p class="mt-2 text-2xl font-semibold text-slate-800 dark:text-slate-100"><?= count($milestones); ?></p>
+    </article>
+    <article class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <p class="text-xs text-slate-500 dark:text-slate-400">Completados</p>
+      <p class="mt-2 text-2xl font-semibold text-slate-800 dark:text-slate-100"><?= $milestoneTotals['completado']; ?></p>
+    </article>
+    <article class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <p class="text-xs text-slate-500 dark:text-slate-400">Proximo vencimiento</p>
+      <p class="mt-2 text-lg font-semibold text-slate-800 dark:text-slate-100"><?= $nextDueDate ? e($nextDueDate) : 'Sin definir'; ?></p>
+    </article>
+    <article class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <p class="text-xs text-slate-500 dark:text-slate-400">Avance global</p>
+      <div class="mt-3">
+        <div class="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+          <span><?= $milestoneProgress; ?>%</span>
+          <span><?= $milestoneTotals['completado']; ?>/<?= max(count($milestones), 1); ?></span>
+        </div>
+        <div class="mt-2 h-2 w-full rounded-full bg-slate-200 dark:bg-slate-800">
+          <div class="h-full rounded-full bg-indigo-500 transition-all dark:bg-indigo-400" style="width: <?= $milestoneProgress; ?>%"></div>
+        </div>
+      </div>
+    </article>
+  </section>
+
   <div class="grid grid-cols-1 gap-4 xl:grid-cols-[2fr,1fr]">
     <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <header class="mb-4 flex flex-wrap items-center justify-between gap-3">
@@ -64,39 +135,53 @@ ob_start();
               $commentErrors = $isCommentError ? ($feedbackFlash['errors'] ?? []) : [];
               $commentOld = $isCommentError ? ($feedbackFlash['old'] ?? []) : [];
             ?>
-            <li id="milestone-<?= $milestoneId; ?>" class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <div class="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100"><?= e($milestone['title']); ?></h3>
+            <li id="milestone-<?= $milestoneId; ?>" class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-lg dark:border-slate-800 dark:bg-slate-900">
+              <span class="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-indigo-500 via-indigo-400 to-indigo-300 opacity-0 transition-opacity duration-300 group-hover:opacity-100"></span>
+              <div class="flex flex-wrap items-start justify-between gap-3 pl-1">
+                <div class="space-y-2">
+                  <div class="flex flex-col gap-1">
+                    <span class="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                      <i data-lucide="flag" class="h-3.5 w-3.5"></i>
+                      Hito
+                    </span>
+                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100"><?= e($milestone['title']); ?></h3>
+                  </div>
                   <?php if (!empty($milestone['description'])): ?>
-                    <p class="mt-1 text-xs text-slate-500 dark:text-slate-400"><?= e($milestone['description']); ?></p>
+                    <p class="text-xs leading-relaxed text-slate-500 dark:text-slate-400"><?= e($milestone['description']); ?></p>
                   <?php endif; ?>
-                  <dl class="mt-2 flex flex-wrap gap-4 text-[11px] text-slate-500 dark:text-slate-400">
+                  <dl class="flex flex-wrap gap-4 text-[11px] text-slate-500 dark:text-slate-400">
                     <div>
                       <dt class="uppercase tracking-wide text-[10px] text-slate-400">Estado</dt>
-                      <dd class="mt-0.5 inline-flex items-center gap-2 rounded-full bg-indigo-50 px-2 py-0.5 text-[11px] font-medium text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-200">
+                      <dd class="mt-0.5 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold <?= $milestoneStatusStyles[$milestone['status']] ?? 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-200'; ?>">
+                        <span class="h-1.5 w-1.5 rounded-full bg-current"></span>
                         <?= e(ucwords(str_replace('_', ' ', $milestone['status']))); ?>
                       </dd>
                     </div>
                     <?php if (!empty($milestone['due_date'])): ?>
                       <div>
                         <dt class="uppercase tracking-wide text-[10px] text-slate-400">Entrega</dt>
-                        <dd class="mt-0.5"><?= e($milestone['due_date']); ?></dd>
+                        <dd class="mt-0.5 inline-flex items-center gap-1">
+                          <i data-lucide="calendar" class="h-3.5 w-3.5"></i>
+                          <?= e($milestone['due_date']); ?>
+                        </dd>
                       </div>
                     <?php endif; ?>
                   </dl>
                 </div>
 
                 <?php if ($user['role'] === 'director' && (int) ($selectedProject['director_id'] ?? 0) === (int) $user['id']): ?>
-                  <form method="post" action="<?= e(url('/milestones/status')); ?>" class="flex items-center gap-2 text-xs">
+                  <form method="post" action="<?= e(url('/milestones/status')); ?>" class="flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50/80 px-3 py-2 text-xs shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
                     <input type="hidden" name="milestone_id" value="<?= $milestoneId; ?>" />
                     <input type="hidden" name="project_id" value="<?= (int) ($selectedProject['id'] ?? 0); ?>" />
-                    <select name="status" class="rounded-lg border border-slate-200 bg-white px-2 py-1 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400">
-                      <?php foreach (['pendiente' => 'Pendiente', 'en_progreso' => 'En progreso', 'en_revision' => 'En revision', 'completado' => 'Completado'] as $value => $label): ?>
+                    <select name="status" class="rounded-lg border border-slate-200 bg-white px-2 py-1 font-medium focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400">
+                      <?php foreach ($milestoneStatuses as $value => $label): ?>
                         <option value="<?= $value; ?>" <?= $milestone['status'] === $value ? 'selected' : ''; ?>><?= $label; ?></option>
                       <?php endforeach; ?>
                     </select>
-                    <button type="submit" class="rounded-lg bg-slate-900 px-3 py-1.5 font-semibold text-white shadow-sm transition hover:bg-slate-700 dark:bg-indigo-600 dark:hover:bg-indigo-500">Actualizar</button>
+                    <button type="submit" class="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-3 py-1.5 font-semibold text-white shadow-sm transition hover:bg-indigo-500">
+                      <i data-lucide="save" class="h-3.5 w-3.5"></i>
+                      Actualizar
+                    </button>
                   </form>
                 <?php endif; ?>
               </div>
@@ -104,35 +189,41 @@ ob_start();
               <div class="mt-4 space-y-3">
                 <?php if ($latestSubmission): ?>
                   <?php $author = $usersMap[(int) $latestSubmission['user_id']] ?? null; ?>
-                  <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 dark:border-slate-800 dark:bg-slate-900/70">
-                    <div class="flex items-start justify-between gap-3">
-                      <div>
-                        <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">Entrega reciente</h4>
-                        <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400">
-                          <?= e($author['full_name'] ?? 'Participante'); ?> &bull; <?= e(substr($latestSubmission['created_at'], 0, 16)); ?>
-                        </p>
-                        <?php if (!empty($latestSubmission['notes'])): ?>
-                          <p class="mt-2 text-sm text-slate-600 dark:text-slate-300"><?= nl2br(e($latestSubmission['notes'])); ?></p>
-                        <?php endif; ?>
-                        <?php if (!empty($latestSubmission['attachment_path'])): ?>
-                          <a href="<?= e(url('/submissions/download?id=' . (int) $latestSubmission['id'])); ?>" class="mt-2 inline-flex items-center gap-2 text-xs font-semibold text-indigo-600 hover:text-indigo-500">
-                            <i data-lucide="paperclip" class="h-4 w-4"></i> Descargar archivo
-                          </a>
-                        <?php endif; ?>
+                  <article class="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+                    <header class="flex items-start justify-between gap-3">
+                      <div class="space-y-1">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-[11px] font-semibold text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200">
+                          <i data-lucide="file-check" class="h-4 w-4"></i>
+                          Entrega reciente
+                        </span>
+                        <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">
+                          <?= e($author['full_name'] ?? 'Participante'); ?>
+                        </h4>
+                        <p class="text-[11px] text-slate-500 dark:text-slate-400">Registrado el <?= e(substr($latestSubmission['created_at'], 0, 16)); ?></p>
                       </div>
-                    </div>
+                      <?php if (!empty($latestSubmission['attachment_path'])): ?>
+                        <a href="<?= e(url('/submissions/download?id=' . (int) $latestSubmission['id'])); ?>" class="inline-flex items-center gap-2 rounded-full bg-indigo-100 px-3 py-1 text-[11px] font-semibold text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-500/20 dark:text-indigo-200">
+                          <i data-lucide="paperclip" class="h-4 w-4"></i>
+                          Descargar
+                        </a>
+                      <?php endif; ?>
+                    </header>
+
+                    <?php if (!empty($latestSubmission['notes'])): ?>
+                      <p class="mt-3 rounded-xl bg-slate-50 px-3 py-2 text-sm text-slate-600 dark:bg-slate-900/60 dark:text-slate-300"><?= nl2br(e($latestSubmission['notes'])); ?></p>
+                    <?php endif; ?>
 
                     <?php $comments = $latestSubmission['comments'] ?? []; ?>
                     <?php if ($comments): ?>
-                      <ul class="mt-3 space-y-2 rounded-xl border border-slate-200 bg-white p-3 text-sm dark:border-slate-800 dark:bg-slate-900">
+                      <ul class="mt-4 space-y-2 text-sm">
                         <?php foreach ($comments as $comment): ?>
                           <?php $commentAuthor = $usersMap[(int) $comment['user_id']] ?? null; ?>
-                          <li class="flex flex-col gap-1">
+                          <li class="rounded-xl border border-slate-200 bg-white/70 px-3 py-2 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
                             <div class="flex items-center justify-between text-[11px] text-slate-500 dark:text-slate-400">
                               <span class="font-semibold text-slate-600 dark:text-slate-200"><?= e($commentAuthor['full_name'] ?? 'Usuario'); ?></span>
                               <span><?= e(substr($comment['created_at'], 0, 16)); ?></span>
                             </div>
-                            <p class="text-sm text-slate-600 dark:text-slate-200"><?= nl2br(e($comment['message'])); ?></p>
+                            <p class="mt-1 text-sm text-slate-600 dark:text-slate-200"><?= nl2br(e($comment['message'])); ?></p>
                           </li>
                         <?php endforeach; ?>
                       </ul>
@@ -143,21 +234,30 @@ ob_start();
                 <?php endif; ?>
 
                 <?php if ($olderSubmissions): ?>
-                  <details class="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900">
-                    <summary class="cursor-pointer font-semibold text-slate-700 dark:text-slate-200">Historial de entregas (<?= count($submissions); ?>)</summary>
+                  <details class="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                    <summary class="flex cursor-pointer items-center gap-2 font-semibold text-slate-700 dark:text-slate-200">
+                      <i data-lucide="archive" class="h-4 w-4"></i>
+                      Historial de entregas (<?= count($submissions); ?>)
+                    </summary>
                     <ul class="mt-3 space-y-3">
                       <?php foreach ($olderSubmissions as $submission): ?>
                         <?php $submissionAuthor = $usersMap[(int) $submission['user_id']] ?? null; ?>
-                        <li class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs dark:border-slate-800 dark:bg-slate-900/80">
+                        <li class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs shadow-sm dark:border-slate-800 dark:bg-slate-900/80">
                           <div class="flex items-center justify-between">
-                            <span class="font-semibold text-slate-600 dark:text-slate-200"><?= e($submissionAuthor['full_name'] ?? 'Usuario'); ?></span>
-                            <span><?= e(substr($submission['created_at'], 0, 16)); ?></span>
+                            <span class="inline-flex items-center gap-1 font-semibold text-slate-600 dark:text-slate-200">
+                              <i data-lucide="user" class="h-3.5 w-3.5"></i>
+                              <?= e($submissionAuthor['full_name'] ?? 'Usuario'); ?>
+                            </span>
+                            <span class="inline-flex items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400">
+                              <i data-lucide="clock" class="h-3.5 w-3.5"></i>
+                              <?= e(substr($submission['created_at'], 0, 16)); ?>
+                            </span>
                           </div>
                           <?php if (!empty($submission['notes'])): ?>
                             <p class="mt-1 text-slate-500 dark:text-slate-400"><?= nl2br(e($submission['notes'])); ?></p>
                           <?php endif; ?>
                           <?php if (!empty($submission['attachment_path'])): ?>
-                            <a href="<?= e(url('/submissions/download?id=' . (int) $submission['id'])); ?>" class="mt-1 inline-flex items-center gap-2 text-xs font-semibold text-indigo-600 hover:text-indigo-500">
+                            <a href="<?= e(url('/submissions/download?id=' . (int) $submission['id'])); ?>" class="mt-1 inline-flex items-center gap-2 text-[11px] font-semibold text-indigo-600 hover:text-indigo-500">
                               <i data-lucide="paperclip" class="h-4 w-4"></i> Descargar archivo
                             </a>
                           <?php endif; ?>
@@ -171,31 +271,44 @@ ob_start();
                   <form method="post" action="<?= e(url('/submissions')); ?>" enctype="multipart/form-data" class="rounded-2xl border border-slate-200 bg-white px-4 py-4 text-sm shadow-sm dark:border-slate-800 dark:bg-slate-900">
                     <input type="hidden" name="milestone_id" value="<?= $milestoneId; ?>" />
                     <input type="hidden" name="project_id" value="<?= (int) ($selectedProject['id'] ?? 0); ?>" />
-                    <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">Enviar avance</h4>
-                    <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400">Comparte notas y adjunta tu entregable.</p>
-
-                    <div class="mt-3 space-y-2">
-                      <label for="notes-<?= $milestoneId; ?>" class="block text-xs font-semibold text-slate-600 dark:text-slate-300">Notas</label>
-                      <textarea id="notes-<?= $milestoneId; ?>" name="notes" rows="3" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" placeholder="Describe el entregable o inquietudes"><?= e($submissionOld['notes'] ?? ''); ?></textarea>
-                      <?php if (!empty($submissionErrors['notes'])): ?>
-                        <p class="text-[11px] text-rose-500"><?= e($submissionErrors['notes']); ?></p>
-                      <?php endif; ?>
+                    <div class="flex items-start justify-between gap-3">
+                      <div>
+                        <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">Enviar avance</h4>
+                        <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400">Comparte notas y adjunta tu entregable.</p>
+                      </div>
+                      <span class="inline-flex items-center gap-1 rounded-full bg-indigo-100 px-2.5 py-1 text-[11px] font-semibold text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200">
+                        <i data-lucide="upload" class="h-3.5 w-3.5"></i>
+                        Entrega
+                      </span>
                     </div>
 
-                    <div class="mt-3 space-y-2">
-                      <label for="attachment-<?= $milestoneId; ?>" class="block text-xs font-semibold text-slate-600 dark:text-slate-300">Archivo (opcional)</label>
-                      <input type="file" id="attachment-<?= $milestoneId; ?>" name="attachment" class="block w-full text-xs text-slate-500 file:mr-3 file:rounded-lg file:border-0 file:bg-indigo-600 file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-white hover:file:bg-indigo-500" />
-                      <?php if (!empty($submissionErrors['attachment'])): ?>
-                        <p class="text-[11px] text-rose-500"><?= e($submissionErrors['attachment']); ?></p>
+                    <div class="mt-4 space-y-3 rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 p-3 dark:border-slate-700 dark:bg-slate-900/50">
+                      <div class="space-y-2">
+                        <label for="notes-<?= $milestoneId; ?>" class="block text-xs font-semibold text-slate-600 dark:text-slate-300">Notas</label>
+                        <textarea id="notes-<?= $milestoneId; ?>" name="notes" rows="3" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" placeholder="Describe el entregable o inquietudes"><?= e($submissionOld['notes'] ?? ''); ?></textarea>
+                        <?php if (!empty($submissionErrors['notes'])): ?>
+                          <p class="text-[11px] text-rose-500"><?= e($submissionErrors['notes']); ?></p>
+                        <?php endif; ?>
+                      </div>
+
+                      <div class="space-y-2">
+                        <label for="attachment-<?= $milestoneId; ?>" class="block text-xs font-semibold text-slate-600 dark:text-slate-300">Archivo (opcional)</label>
+                        <input type="file" id="attachment-<?= $milestoneId; ?>" name="attachment" class="block w-full text-xs text-slate-500 file:mr-3 file:rounded-lg file:border-0 file:bg-indigo-600 file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-white hover:file:bg-indigo-500" />
+                        <?php if (!empty($submissionErrors['attachment'])): ?>
+                          <p class="text-[11px] text-rose-500"><?= e($submissionErrors['attachment']); ?></p>
+                        <?php endif; ?>
+                      </div>
+
+                      <?php if (!empty($submissionErrors['submission'])): ?>
+                        <p class="text-[11px] text-rose-500"><?= e($submissionErrors['submission']); ?></p>
                       <?php endif; ?>
                     </div>
-
-                    <?php if (!empty($submissionErrors['submission'])): ?>
-                      <p class="mt-2 text-[11px] text-rose-500"><?= e($submissionErrors['submission']); ?></p>
-                    <?php endif; ?>
 
                     <div class="mt-4 text-right">
-                      <button type="submit" class="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200">Enviar avance</button>
+                      <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200">
+                        <i data-lucide="send" class="h-4 w-4"></i>
+                        Enviar avance
+                      </button>
                     </div>
                   </form>
                 <?php endif; ?>
@@ -204,8 +317,14 @@ ob_start();
                   <form method="post" action="<?= e(url('/comments')); ?>" class="rounded-2xl border border-slate-200 bg-white px-4 py-4 text-sm shadow-sm dark:border-slate-800 dark:bg-slate-900">
                     <input type="hidden" name="submission_id" value="<?= (int) $latestSubmission['id']; ?>" />
                     <input type="hidden" name="project_id" value="<?= (int) ($selectedProject['id'] ?? 0); ?>" />
-                    <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200"><?= $user['role'] === 'director' ? 'Dejar feedback' : 'Agregar comentario'; ?></h4>
-                    <div class="mt-2">
+                    <div class="flex items-start justify-between gap-3">
+                      <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200"><?= $user['role'] === 'director' ? 'Dejar feedback' : 'Agregar comentario'; ?></h4>
+                      <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                        <i data-lucide="message-circle" class="h-3.5 w-3.5"></i>
+                        Conversacion
+                      </span>
+                    </div>
+                    <div class="mt-3">
                       <label for="comment-<?= $milestoneId; ?>" class="mb-1 block text-xs font-semibold text-slate-600 dark:text-slate-300">Comentario</label>
                       <textarea id="comment-<?= $milestoneId; ?>" name="message" rows="3" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" placeholder="Comparte retroalimentacion o dudas"><?= e($commentOld['message'] ?? ''); ?></textarea>
                       <?php if (!empty($commentErrors['message'])): ?>
@@ -216,7 +335,10 @@ ob_start();
                       <?php endif; ?>
                     </div>
                     <div class="mt-4 text-right">
-                      <button type="submit" class="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 dark:bg-indigo-600 dark:hover:bg-indigo-500">Publicar</button>
+                      <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 dark:bg-indigo-600 dark:hover:bg-indigo-500">
+                        <i data-lucide="send" class="h-4 w-4"></i>
+                        Publicar
+                      </button>
                     </div>
                   </form>
                 <?php endif; ?>
@@ -229,41 +351,95 @@ ob_start();
 
     <aside class="space-y-4">
       <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Resumen del proyecto</h2>
+            <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Estado actual y responsables del proyecto seleccionado.</p>
+          </div>
+          <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+            <i data-lucide="info" class="h-3.5 w-3.5"></i>
+            Vista
+          </span>
+        </div>
+        <dl class="mt-4 space-y-3 text-xs text-slate-600 dark:text-slate-300">
+          <div class="flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-900/50">
+            <dt class="font-semibold text-slate-500 dark:text-slate-400">Proyecto</dt>
+            <dd class="text-right font-medium text-slate-700 dark:text-slate-100"><?= e($selectedProject['title'] ?? 'Selecciona un proyecto'); ?></dd>
+          </div>
+          <div class="flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-900/50">
+            <dt class="font-semibold text-slate-500 dark:text-slate-400">Director</dt>
+            <dd class="text-right"><?= e($usersMap[(int) ($selectedProject['director_id'] ?? 0)]['full_name'] ?? 'Sin asignar'); ?></dd>
+          </div>
+          <div class="rounded-2xl border border-dashed border-slate-200 bg-white/70 p-3 dark:border-slate-700 dark:bg-slate-900/50">
+            <h3 class="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Distribucion de hitos</h3>
+            <ul class="mt-2 space-y-2">
+              <?php foreach ($milestoneStatuses as $statusKey => $label): ?>
+                <li class="flex items-center justify-between text-[11px]">
+                  <span class="inline-flex items-center gap-2 font-medium text-slate-600 dark:text-slate-300">
+                    <span class="h-2 w-2 rounded-full <?= [
+                      'pendiente' => 'bg-amber-500',
+                      'en_progreso' => 'bg-sky-500',
+                      'en_revision' => 'bg-indigo-500',
+                      'completado' => 'bg-emerald-500',
+                    ][$statusKey] ?? 'bg-slate-400'; ?>"></span>
+                    <?= e($label); ?>
+                  </span>
+                  <span class="font-semibold text-slate-700 dark:text-slate-100"><?= $milestoneTotals[$statusKey] ?? 0; ?></span>
+                </li>
+              <?php endforeach; ?>
+            </ul>
+          </div>
+        </dl>
+      </section>
+
+      <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
         <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Registrar nuevo hito</h2>
         <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Define tareas y fechas clave para el proyecto actual.</p>
 
-        <form method="post" action="<?= e(url('/milestones')); ?>" class="mt-4 space-y-3">
+        <form method="post" action="<?= e(url('/milestones')); ?>" class="mt-4 space-y-4">
           <input type="hidden" name="project_id" value="<?= (int) ($selectedProject['id'] ?? 0); ?>" />
 
-          <div>
-            <label for="title" class="mb-1 block text-xs font-semibold text-slate-600 dark:text-slate-300">Titulo</label>
-            <input type="text" id="title" name="title" value="<?= e($old['title'] ?? ''); ?>" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" required />
-            <?php if (!empty($errors['title'])): ?>
-              <p class="mt-1 text-[11px] text-rose-500"><?= e($errors['title']); ?></p>
+          <div class="space-y-3 rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 p-4 dark:border-slate-700 dark:bg-slate-900/50">
+            <div class="space-y-2">
+              <label for="title" class="block text-xs font-semibold text-slate-600 dark:text-slate-300">Titulo</label>
+              <input type="text" id="title" name="title" value="<?= e($old['title'] ?? ''); ?>" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" required />
+              <?php if (!empty($errors['title'])): ?>
+                <p class="text-[11px] text-rose-500"><?= e($errors['title']); ?></p>
+              <?php endif; ?>
+            </div>
+
+            <div class="space-y-2">
+              <label for="description" class="block text-xs font-semibold text-slate-600 dark:text-slate-300">Descripcion</label>
+              <textarea id="description" name="description" rows="3" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" placeholder="Describe el entregable o criterio de avance"><?= e($old['description'] ?? ''); ?></textarea>
+            </div>
+
+            <div class="space-y-2">
+              <label for="due_date" class="block text-xs font-semibold text-slate-600 dark:text-slate-300">Fecha de entrega</label>
+              <input type="date" id="due_date" name="due_date" value="<?= e($old['due_date'] ?? ''); ?>" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" />
+              <?php if (!empty($errors['due_date'])): ?>
+                <p class="text-[11px] text-rose-500"><?= e($errors['due_date']); ?></p>
+              <?php endif; ?>
+            </div>
+
+            <?php if (!empty($errors['project_id'])): ?>
+              <p class="text-[11px] text-rose-500"><?= e($errors['project_id']); ?></p>
             <?php endif; ?>
           </div>
-
-          <div>
-            <label for="description" class="mb-1 block text-xs font-semibold text-slate-600 dark:text-slate-300">Descripcion</label>
-            <textarea id="description" name="description" rows="3" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" placeholder="Describe el entregable o criterio de avance"><?= e($old['description'] ?? ''); ?></textarea>
-          </div>
-
-          <div>
-            <label for="due_date" class="mb-1 block text-xs font-semibold text-slate-600 dark:text-slate-300">Fecha de entrega</label>
-            <input type="date" id="due_date" name="due_date" value="<?= e($old['due_date'] ?? ''); ?>" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" />
-            <?php if (!empty($errors['due_date'])): ?>
-              <p class="mt-1 text-[11px] text-rose-500"><?= e($errors['due_date']); ?></p>
-            <?php endif; ?>
-          </div>
-
-          <?php if (!empty($errors['project_id'])): ?>
-            <p class="text-[11px] text-rose-500"><?= e($errors['project_id']); ?></p>
-          <?php endif; ?>
 
           <div class="pt-2">
             <button type="submit" class="w-full rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200">Agregar hito</button>
           </div>
         </form>
+      </section>
+
+      <section class="rounded-2xl border border-slate-200 bg-gradient-to-br from-slate-900 via-slate-900 to-slate-700 p-5 text-slate-100 shadow-sm dark:border-slate-700">
+        <h2 class="text-sm font-semibold">Consejos de seguimiento</h2>
+        <p class="mt-1 text-xs text-slate-300">Fortalece la comunicacion con estudiantes y directores.</p>
+        <ul class="mt-4 space-y-3 text-xs">
+          <li class="flex items-start gap-2"><i data-lucide="alert-circle" class="mt-0.5 h-4 w-4 flex-none"></i><span>Prioriza hitos proximos compartiendo recordatorios claros.</span></li>
+          <li class="flex items-start gap-2"><i data-lucide="check-circle-2" class="mt-0.5 h-4 w-4 flex-none"></i><span>Confirma la recepcion de feedback para asegurar alineacion.</span></li>
+          <li class="flex items-start gap-2"><i data-lucide="timeline" class="mt-0.5 h-4 w-4 flex-none"></i><span>Documenta acuerdos clave en los comentarios para futuras revisiones.</span></li>
+        </ul>
       </section>
     </aside>
   </div>

--- a/app/Views/progress/index.php
+++ b/app/Views/progress/index.php
@@ -17,8 +17,58 @@ $cardData = [
     ['label' => 'En revision', 'value' => $milestoneCounts['en_revision'] ?? 0, 'icon' => 'inbox'],
 ];
 
+$statusPalette = [
+    'planeacion' => ['label' => 'Planeacion', 'color' => 'bg-sky-500'],
+    'en_progreso' => ['label' => 'En progreso', 'color' => 'bg-indigo-500'],
+    'en_revision' => ['label' => 'En revision', 'color' => 'bg-amber-500'],
+    'finalizado' => ['label' => 'Finalizado', 'color' => 'bg-emerald-500'],
+];
+
+$progressInsights = [
+    [
+        'title' => 'Tasa de finalizacion',
+        'value' => $completionRate . '%',
+        'description' => 'Porcentaje promedio de hitos completados en todos los proyectos activos.',
+        'icon' => 'activity',
+    ],
+    [
+        'title' => 'Hitos pendientes',
+        'value' => max(0, ($milestoneCounts['total'] ?? 0) - ($milestoneCounts['completado'] ?? 0)),
+        'description' => 'Entregables que requieren atencion para alcanzar la meta de titulacion.',
+        'icon' => 'flag',
+    ],
+    [
+        'title' => 'En revision',
+        'value' => $milestoneCounts['en_revision'] ?? 0,
+        'description' => 'Hitos que esperan feedback por parte de los directores.',
+        'icon' => 'file-search',
+    ],
+];
+
 ob_start();
 ?>
+<section class="mb-5 rounded-3xl border border-slate-200 bg-gradient-to-br from-indigo-600 via-indigo-500 to-sky-500 p-6 text-white shadow-sm dark:border-slate-800">
+  <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <div>
+      <p class="text-xs uppercase tracking-[0.2em] text-indigo-100/80">Panel de progreso</p>
+      <h2 class="mt-2 text-2xl font-semibold">Visibilidad integral de proyectos y avances</h2>
+      <p class="mt-1 max-w-2xl text-sm text-indigo-100/90">Consulta el estado agregado de los proyectos de titulacion, detecta cuellos de botella y prioriza acciones para mantener el ritmo de entrega.</p>
+    </div>
+    <div class="grid gap-3 text-sm lg:grid-cols-3">
+      <?php foreach ($progressInsights as $insight): ?>
+        <article class="rounded-2xl bg-white/15 p-4 shadow-sm">
+          <div class="flex items-center gap-2 text-xs uppercase tracking-wide text-indigo-100/80">
+            <i data-lucide="<?= e($insight['icon']); ?>" class="h-4 w-4"></i>
+            <?= e($insight['title']); ?>
+          </div>
+          <p class="mt-2 text-xl font-semibold text-white"><?= e($insight['value']); ?></p>
+          <p class="mt-1 text-[11px] text-indigo-100/80"><?= e($insight['description']); ?></p>
+        </article>
+      <?php endforeach; ?>
+    </div>
+  </div>
+</section>
+
 <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
   <?php foreach ($cardData as $card): ?>
     <article class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
@@ -37,14 +87,18 @@ ob_start();
 
 <div class="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-[2fr,1fr]">
   <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-    <header class="mb-4 flex items-center justify-between">
+    <header class="mb-4 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
       <div>
         <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Avance por proyecto</h2>
         <p class="text-xs text-slate-500 dark:text-slate-400">Progreso calculado con base en hitos completados.</p>
       </div>
-      <div class="text-right text-xs text-slate-500 dark:text-slate-400">
-        <p class="uppercase tracking-wide text-[10px] text-slate-400">Tasa de finalizacion</p>
-        <p class="text-lg font-semibold text-slate-800 dark:text-slate-100"><?= $completionRate; ?>%</p>
+      <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+        <?php foreach ($statusPalette as $statusKey => $meta): ?>
+          <span class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 font-medium shadow-sm dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300">
+            <span class="h-1.5 w-1.5 rounded-full <?= $meta['color']; ?>"></span>
+            <?= e($meta['label']); ?> (<?= (int) ($statusCounts[$statusKey] ?? 0); ?>)
+          </span>
+        <?php endforeach; ?>
       </div>
     </header>
 
@@ -55,18 +109,27 @@ ob_start();
     <?php else: ?>
       <ul class="space-y-3">
         <?php foreach ($projectsProgress as $project): ?>
-          <li class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 dark:border-slate-800 dark:bg-slate-900/70">
-            <div class="flex items-start justify-between gap-3">
-              <div>
+          <li class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-slate-50/70 p-4 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:bg-white hover:shadow-lg dark:border-slate-800 dark:bg-slate-900/70 dark:hover:border-indigo-500/40">
+            <span class="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-indigo-500 via-indigo-400 to-sky-400 opacity-0 transition-opacity duration-300 group-hover:opacity-100"></span>
+            <div class="flex items-start justify-between gap-3 pl-1">
+              <div class="space-y-2">
                 <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100"><?= e($project['title']); ?></h3>
-                <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400">Estado: <?= e(ucwords(str_replace('_', ' ', $project['status']))); ?></p>
+                <p class="flex items-center gap-2 text-[11px] text-slate-500 dark:text-slate-400">
+                  <span class="inline-flex items-center gap-1 rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                    <?= e(ucwords(str_replace('_', ' ', $project['status']))); ?>
+                  </span>
+                  &bull; <?= $project['done']; ?>/<?= $project['total']; ?> hitos completados
+                </p>
               </div>
-              <p class="text-sm font-semibold text-slate-700 dark:text-slate-200"><?= $project['progress']; ?>%</p>
+              <div class="text-right">
+                <p class="text-xl font-semibold text-indigo-600 dark:text-indigo-400"><?= $project['progress']; ?>%</p>
+                <p class="text-[11px] text-slate-500 dark:text-slate-400">Avance acumulado</p>
+              </div>
             </div>
             <div class="mt-3 h-2 w-full rounded-full bg-slate-200 dark:bg-slate-800">
-              <div class="h-full rounded-full bg-indigo-500 dark:bg-indigo-400" style="width: <?= $project['progress']; ?>%"></div>
+              <div class="h-full rounded-full bg-indigo-500 transition-all dark:bg-indigo-400" style="width: <?= $project['progress']; ?>%"></div>
             </div>
-            <dl class="mt-2 flex flex-wrap gap-4 text-[11px] text-slate-500 dark:text-slate-400">
+            <dl class="mt-3 flex flex-wrap gap-4 text-[11px] text-slate-500 dark:text-slate-400">
               <div>
                 <dt class="uppercase tracking-wide text-[10px] text-slate-400">Hitos</dt>
                 <dd><?= $project['done']; ?>/<?= $project['total']; ?></dd>
@@ -91,10 +154,16 @@ ob_start();
       <?php else: ?>
         <ul class="mt-3 space-y-2 text-xs text-slate-600 dark:text-slate-300">
           <?php foreach ($upcoming as $item): ?>
-            <li class="rounded-xl border border-slate-200 bg-white px-3 py-2 dark:border-slate-800 dark:bg-slate-900">
-              <p class="font-semibold text-slate-700 dark:text-slate-200"><?= e($item['title']); ?></p>
-              <p class="text-[11px] text-slate-500 dark:text-slate-400"><?= e($item['project']); ?></p>
-              <p class="mt-1 text-[11px] <?= $item['overdue'] ? 'text-rose-500' : 'text-slate-500'; ?>">Entrega: <?= e($item['due_date']); ?><?= $item['overdue'] ? ' (atrasado)' : ''; ?></p>
+            <li class="rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+              <div class="flex items-center justify-between">
+                <p class="font-semibold text-slate-700 dark:text-slate-200"><?= e($item['title']); ?></p>
+                <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold <?= $item['overdue'] ? 'bg-rose-100 text-rose-600 dark:bg-rose-500/20 dark:text-rose-200' : 'bg-emerald-100 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200'; ?>">
+                  <i data-lucide="clock" class="h-3.5 w-3.5"></i>
+                  <?= $item['overdue'] ? 'Atrasado' : 'A tiempo'; ?>
+                </span>
+              </div>
+              <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400"><?= e($item['project']); ?></p>
+              <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400">Entrega: <?= e($item['due_date']); ?></p>
             </li>
           <?php endforeach; ?>
         </ul>
@@ -109,7 +178,7 @@ ob_start();
       <?php else: ?>
         <ul class="mt-3 space-y-2 text-xs text-slate-600 dark:text-slate-300">
           <?php foreach ($recent as $item): ?>
-            <li class="rounded-xl border border-slate-200 bg-white px-3 py-2 dark:border-slate-800 dark:bg-slate-900">
+            <li class="rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm dark:border-slate-800 dark:bg-slate-900">
               <p class="font-semibold text-slate-700 dark:text-slate-200"><?= e($item['title']); ?></p>
               <p class="text-[11px] text-slate-500 dark:text-slate-400"><?= e($item['project']); ?></p>
               <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400">Actualizado: <?= e(substr($item['updated_at'], 0, 16)); ?></p>
@@ -117,6 +186,16 @@ ob_start();
           <?php endforeach; ?>
         </ul>
       <?php endif; ?>
+    </section>
+
+    <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Recomendaciones</h2>
+      <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Acciones sugeridas para mejorar el seguimiento.</p>
+      <ul class="mt-3 space-y-2 text-xs text-slate-600 dark:text-slate-300">
+        <li class="flex items-start gap-2"><i data-lucide="sparkles" class="mt-0.5 h-4 w-4 flex-none"></i><span>Reconoce avances completos en las reuniones semanales para mantener la motivacion.</span></li>
+        <li class="flex items-start gap-2"><i data-lucide="bell-ring" class="mt-0.5 h-4 w-4 flex-none"></i><span>Agenda recordatorios para hitos con fecha proxima desde el modulo de hitos.</span></li>
+        <li class="flex items-start gap-2"><i data-lucide="users" class="mt-0.5 h-4 w-4 flex-none"></i><span>Comparte este reporte con directores para alinear expectativas.</span></li>
+      </ul>
     </section>
   </aside>
 </div>

--- a/app/Views/projects/index.php
+++ b/app/Views/projects/index.php
@@ -17,6 +17,59 @@ $statusLabels = [
     'en_revision' => 'En revision',
     'finalizado' => 'Finalizado',
 ];
+$statusStyles = [
+    'planeacion' => 'bg-sky-100 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200',
+    'en_progreso' => 'bg-indigo-100 text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200',
+    'en_revision' => 'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200',
+    'finalizado' => 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200',
+];
+
+$statusTotals = [
+    'planeacion' => 0,
+    'en_progreso' => 0,
+    'en_revision' => 0,
+    'finalizado' => 0,
+];
+
+foreach ($projects as $project) {
+    $status = $project['status'] ?? '';
+    if (array_key_exists($status, $statusTotals)) {
+        $statusTotals[$status] += 1;
+    }
+}
+
+$projectHighlights = [
+    [
+        'label' => 'Proyectos en planeacion',
+        'value' => $statusTotals['planeacion'],
+        'icon' => 'compass',
+        'accent' => 'from-sky-400/90 to-sky-500/70 text-sky-900',
+    ],
+    [
+        'label' => 'En progreso activo',
+        'value' => $statusTotals['en_progreso'],
+        'icon' => 'loader-2',
+        'accent' => 'from-indigo-400/90 to-indigo-500/70 text-indigo-900',
+    ],
+    [
+        'label' => 'Pendientes de revision',
+        'value' => $statusTotals['en_revision'],
+        'icon' => 'clipboard-check',
+        'accent' => 'from-amber-300/90 to-amber-400/70 text-amber-900',
+    ],
+    [
+        'label' => 'Finalizados',
+        'value' => $statusTotals['finalizado'],
+        'icon' => 'medal',
+        'accent' => 'from-emerald-300/90 to-emerald-400/70 text-emerald-900',
+    ],
+];
+
+$roleTips = [
+    'director' => 'Monitorea la carga de tus estudiantes, asigna nuevos proyectos y mantente al tanto de los estados.',
+    'estudiante' => 'Visualiza el estatus general, identifica tareas pendientes y registra tus avances con tu director.',
+    'admin' => 'Administra asignaciones y estados para dar visibilidad al progreso institucional.',
+];
 
 ob_start();
 ?>
@@ -31,6 +84,71 @@ ob_start();
     <?= e($errors['general']); ?>
   </div>
 <?php endif; ?>
+
+<?php if ($projectCount > 0): ?>
+  <section class="mb-5 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+    <?php foreach ($projectHighlights as $highlight): ?>
+      <article class="relative overflow-hidden rounded-2xl border border-transparent bg-gradient-to-br <?= $highlight['accent']; ?> p-5 shadow-sm">
+        <div class="absolute inset-0 bg-white/10 mix-blend-soft-light"></div>
+        <div class="relative flex items-start justify-between gap-3">
+          <div>
+            <p class="text-xs font-medium uppercase tracking-wide/loose text-slate-900/70">
+              <?= e($highlight['label']); ?>
+            </p>
+            <p class="mt-3 text-2xl font-semibold"><?= (int) $highlight['value']; ?></p>
+          </div>
+          <span class="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-white/80 text-slate-900/70">
+            <i data-lucide="<?= e($highlight['icon']); ?>" class="h-5 w-5"></i>
+          </span>
+        </div>
+      </article>
+    <?php endforeach; ?>
+  </section>
+<?php endif; ?>
+
+<section class="mb-5 grid gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900 lg:grid-cols-[1.2fr,1fr]">
+  <div>
+    <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Resumen operativo</h2>
+    <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+      <?= e($roleTips[$user['role']] ?? 'Gestiona la cartera de proyectos y mantiene informados a los involucrados.'); ?>
+    </p>
+    <dl class="mt-4 grid grid-cols-2 gap-3 text-xs text-slate-600 dark:text-slate-300 sm:grid-cols-3">
+      <div class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-800 dark:bg-slate-900/60">
+        <dt class="text-[10px] font-semibold uppercase tracking-wide text-slate-400">Total</dt>
+        <dd class="mt-1 text-lg font-semibold text-slate-800 dark:text-slate-100"><?= $projectCount; ?></dd>
+      </div>
+      <div class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-800 dark:bg-slate-900/60">
+        <dt class="text-[10px] font-semibold uppercase tracking-wide text-slate-400">En progreso</dt>
+        <dd class="mt-1 text-lg font-semibold text-slate-800 dark:text-slate-100"><?= $statusTotals['en_progreso']; ?></dd>
+      </div>
+      <div class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-800 dark:bg-slate-900/60">
+        <dt class="text-[10px] font-semibold uppercase tracking-wide text-slate-400">Finalizados</dt>
+        <dd class="mt-1 text-lg font-semibold text-slate-800 dark:text-slate-100"><?= $statusTotals['finalizado']; ?></dd>
+      </div>
+    </dl>
+  </div>
+  <div class="space-y-3">
+    <div class="flex items-center justify-between text-[11px] font-medium text-slate-500 dark:text-slate-400">
+      <span>Filtros rapidos</span>
+      <a href="<?= e(url('/projects')); ?>" class="inline-flex items-center gap-1 text-indigo-600 hover:text-indigo-500">
+        <i data-lucide="rotate-ccw" class="h-3.5 w-3.5"></i> Reiniciar
+      </a>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <?php foreach ($statusLabels as $statusKey => $statusLabel): ?>
+        <span class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-[11px] font-medium text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300">
+          <span class="h-2 w-2 rounded-full <?= [
+            'planeacion' => 'bg-sky-500',
+            'en_progreso' => 'bg-indigo-500',
+            'en_revision' => 'bg-amber-500',
+            'finalizado' => 'bg-emerald-500',
+          ][$statusKey] ?? 'bg-slate-400'; ?>"></span>
+          <?= e($statusLabel); ?> (<?= $statusTotals[$statusKey] ?? 0; ?>)
+        </span>
+      <?php endforeach; ?>
+    </div>
+  </div>
+</section>
 
 <div class="grid grid-cols-1 gap-4 xl:grid-cols-[2fr,1fr]">
   <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
@@ -53,8 +171,9 @@ ob_start();
             $student = $peopleMap[(int) $project['student_id']] ?? null;
             $director = $peopleMap[(int) $project['director_id']] ?? null;
           ?>
-          <li class="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 transition hover:border-indigo-200 hover:bg-white dark:border-slate-800 dark:bg-slate-900/60 dark:hover:border-indigo-500/40">
-            <div class="flex flex-col gap-3">
+          <li class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-slate-50/60 p-4 transition-all duration-300 hover:-translate-y-0.5 hover:border-indigo-200 hover:bg-white hover:shadow-lg dark:border-slate-800 dark:bg-slate-900/60 dark:hover:border-indigo-500/40">
+            <span class="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-indigo-500/80 via-indigo-400/70 to-indigo-300/60 opacity-0 transition-opacity duration-300 group-hover:opacity-100"></span>
+            <div class="flex flex-col gap-3 pl-1">
               <div class="flex flex-wrap items-start justify-between gap-3">
                 <div>
                   <h3 class="text-base font-semibold text-slate-800 dark:text-slate-100"><?= e($project['title']); ?></h3>
@@ -69,30 +188,31 @@ ob_start();
               </div>
 
               <div class="grid grid-cols-1 gap-2 text-xs text-slate-600 dark:text-slate-300 sm:grid-cols-3">
-                <div class="rounded-xl border border-slate-200 bg-white px-3 py-2 dark:border-slate-800 dark:bg-slate-900">
+                <div class="rounded-xl border border-slate-200 bg-white px-3 py-2 shadow-sm dark:border-slate-800 dark:bg-slate-900">
                   <p class="text-[10px] font-semibold uppercase tracking-wide text-slate-400">Estudiante</p>
                   <p class="mt-1 font-medium"><?= e($student['full_name'] ?? 'Sin asignar'); ?></p>
                   <?php if (!empty($student['email'])): ?>
                     <p class="text-[11px] text-slate-500 dark:text-slate-400"><?= e($student['email']); ?></p>
                   <?php endif; ?>
                 </div>
-                <div class="rounded-xl border border-slate-200 bg-white px-3 py-2 dark:border-slate-800 dark:bg-slate-900">
+                <div class="rounded-xl border border-slate-200 bg-white px-3 py-2 shadow-sm dark:border-slate-800 dark:bg-slate-900">
                   <p class="text-[10px] font-semibold uppercase tracking-wide text-slate-400">Director</p>
                   <p class="mt-1 font-medium"><?= e($director['full_name'] ?? 'Sin asignar'); ?></p>
                   <?php if (!empty($director['email'])): ?>
                     <p class="text-[11px] text-slate-500 dark:text-slate-400"><?= e($director['email']); ?></p>
                   <?php endif; ?>
                 </div>
-                <div class="rounded-xl border border-slate-200 bg-white px-3 py-2 dark:border-slate-800 dark:bg-slate-900">
+                <div class="rounded-xl border border-slate-200 bg-white px-3 py-2 shadow-sm dark:border-slate-800 dark:bg-slate-900">
                   <p class="text-[10px] font-semibold uppercase tracking-wide text-slate-400">Estado</p>
-                  <p class="mt-1 inline-flex items-center gap-2 rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                  <span class="mt-1 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold <?= $statusStyles[$project['status']] ?? 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-200'; ?>">
+                    <span class="h-1.5 w-1.5 rounded-full bg-current"></span>
                     <?= e($statusLabels[$project['status']] ?? ucfirst($project['status'])); ?>
-                  </p>
+                  </span>
                 </div>
               </div>
 
               <?php if ($user['role'] === 'director' && (int) $project['director_id'] === (int) $user['id']): ?>
-                <form method="post" action="<?= e(url('/projects/status')); ?>" class="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs dark:border-slate-800 dark:bg-slate-900">
+                <form method="post" action="<?= e(url('/projects/status')); ?>" class="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs shadow-sm dark:border-slate-800 dark:bg-slate-900">
                   <input type="hidden" name="project_id" value="<?= (int) $project['id']; ?>" />
                   <label for="status-<?= (int) $project['id']; ?>" class="font-semibold text-slate-600 dark:text-slate-300">Actualizar estado</label>
                   <select id="status-<?= (int) $project['id']; ?>" name="status" class="rounded-lg border border-slate-200 bg-white px-2 py-1 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400">
@@ -112,55 +232,80 @@ ob_start();
 
   <aside class="space-y-4">
     <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Nuevo proyecto</h2>
-      <p class="mt-1 text-xs text-slate-500 dark:text-slate-400"><?= $user['role'] === 'director' ? 'Asigna un nuevo proyecto a un estudiante.' : 'Propone tu proyecto y asigna un director.'; ?></p>
-
-      <form method="post" action="<?= e(url('/projects')); ?>" class="mt-4 space-y-3">
+      <div class="flex items-start justify-between gap-3">
         <div>
-          <label for="title" class="mb-1 block text-xs font-semibold text-slate-600 dark:text-slate-300">Titulo</label>
-          <input type="text" id="title" name="title" value="<?= e($old['title'] ?? ''); ?>" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" required />
-          <?php if (!empty($errors['title'])): ?>
-            <p class="mt-1 text-[11px] text-rose-500"><?= e($errors['title']); ?></p>
+          <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Nuevo proyecto</h2>
+          <p class="mt-1 text-xs text-slate-500 dark:text-slate-400"><?= $user['role'] === 'director' ? 'Asigna un nuevo proyecto a un estudiante.' : 'Propone tu proyecto y asigna un director.'; ?></p>
+        </div>
+        <span class="inline-flex items-center gap-1 rounded-full bg-indigo-100 px-2.5 py-1 text-[11px] font-semibold text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200">
+          <i data-lucide="sparkles" class="h-3.5 w-3.5"></i>
+          Paso a paso
+        </span>
+      </div>
+
+      <form method="post" action="<?= e(url('/projects')); ?>" class="mt-4 space-y-4">
+        <div class="space-y-3 rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 p-4 dark:border-slate-700 dark:bg-slate-900/40">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Datos generales</h3>
+          <div class="space-y-2">
+            <label for="title" class="block text-xs font-semibold text-slate-600 dark:text-slate-300">Titulo</label>
+            <input type="text" id="title" name="title" value="<?= e($old['title'] ?? ''); ?>" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" required />
+            <?php if (!empty($errors['title'])): ?>
+              <p class="text-[11px] text-rose-500"><?= e($errors['title']); ?></p>
+            <?php endif; ?>
+          </div>
+          <div class="space-y-2">
+            <label for="description" class="block text-xs font-semibold text-slate-600 dark:text-slate-300">Descripcion</label>
+            <textarea id="description" name="description" rows="3" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" placeholder="Contexto breve del proyecto"><?= e($old['description'] ?? ''); ?></textarea>
+          </div>
+        </div>
+
+        <div class="space-y-3 rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 p-4 dark:border-slate-700 dark:bg-slate-900/40">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Asignaciones</h3>
+          <?php if ($user['role'] === 'director'): ?>
+            <div class="space-y-2">
+              <label for="student_id" class="block text-xs font-semibold text-slate-600 dark:text-slate-300">Estudiante</label>
+              <select id="student_id" name="student_id" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400">
+                <option value="">Selecciona estudiante</option>
+                <?php foreach ($students as $student): ?>
+                  <option value="<?= (int) $student['id']; ?>" <?= isset($old['student_id']) && (int) $old['student_id'] === (int) $student['id'] ? 'selected' : ''; ?>><?= e($student['full_name']); ?> (<?= e($student['email']); ?>)</option>
+                <?php endforeach; ?>
+              </select>
+              <?php if (!empty($errors['student_id'])): ?>
+                <p class="text-[11px] text-rose-500"><?= e($errors['student_id']); ?></p>
+              <?php endif; ?>
+            </div>
+          <?php else: ?>
+            <div class="space-y-2">
+              <label for="director_id" class="block text-xs font-semibold text-slate-600 dark:text-slate-300">Director</label>
+              <select id="director_id" name="director_id" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400">
+                <option value="">Selecciona director</option>
+                <?php foreach ($directors as $director): ?>
+                  <option value="<?= (int) $director['id']; ?>" <?= isset($old['director_id']) && (int) $old['director_id'] === (int) $director['id'] ? 'selected' : ''; ?>><?= e($director['full_name']); ?> (<?= e($director['email']); ?>)</option>
+                <?php endforeach; ?>
+              </select>
+              <?php if (!empty($errors['director_id'])): ?>
+                <p class="text-[11px] text-rose-500"><?= e($errors['director_id']); ?></p>
+              <?php endif; ?>
+            </div>
           <?php endif; ?>
         </div>
 
-        <div>
-          <label for="description" class="mb-1 block text-xs font-semibold text-slate-600 dark:text-slate-300">Descripcion</label>
-          <textarea id="description" name="description" rows="3" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400" placeholder="Contexto breve del proyecto"><?= e($old['description'] ?? ''); ?></textarea>
-        </div>
-
-        <?php if ($user['role'] === 'director'): ?>
-          <div>
-            <label for="student_id" class="mb-1 block text-xs font-semibold text-slate-600 dark:text-slate-300">Estudiante</label>
-            <select id="student_id" name="student_id" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400">
-              <option value="">Selecciona estudiante</option>
-              <?php foreach ($students as $student): ?>
-                <option value="<?= (int) $student['id']; ?>" <?= isset($old['student_id']) && (int) $old['student_id'] === (int) $student['id'] ? 'selected' : ''; ?>><?= e($student['full_name']); ?> (<?= e($student['email']); ?>)</option>
-              <?php endforeach; ?>
-            </select>
-            <?php if (!empty($errors['student_id'])): ?>
-              <p class="mt-1 text-[11px] text-rose-500"><?= e($errors['student_id']); ?></p>
-            <?php endif; ?>
-          </div>
-        <?php else: ?>
-          <div>
-            <label for="director_id" class="mb-1 block text-xs font-semibold text-slate-600 dark:text-slate-300">Director</label>
-            <select id="director_id" name="director_id" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400">
-              <option value="">Selecciona director</option>
-              <?php foreach ($directors as $director): ?>
-                <option value="<?= (int) $director['id']; ?>" <?= isset($old['director_id']) && (int) $old['director_id'] === (int) $director['id'] ? 'selected' : ''; ?>><?= e($director['full_name']); ?> (<?= e($director['email']); ?>)</option>
-              <?php endforeach; ?>
-            </select>
-            <?php if (!empty($errors['director_id'])): ?>
-              <p class="mt-1 text-[11px] text-rose-500"><?= e($errors['director_id']); ?></p>
-            <?php endif; ?>
-          </div>
-        <?php endif; ?>
-
-        <div class="pt-2">
+        <div class="space-y-3 rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 p-4 dark:border-slate-700 dark:bg-slate-900/40">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Confirmacion</h3>
+          <p class="text-[11px] text-slate-500 dark:text-slate-400">Revisa que la informacion sea correcta antes de enviar. Podras actualizarla desde la lista de proyectos.</p>
           <button type="submit" class="w-full rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200">Guardar proyecto</button>
         </div>
       </form>
+    </section>
+
+    <section class="rounded-2xl border border-slate-200 bg-gradient-to-br from-slate-900 via-slate-900 to-slate-700 p-5 text-slate-100 shadow-sm dark:border-slate-700">
+      <h2 class="text-sm font-semibold">Buenas practicas</h2>
+      <p class="mt-1 text-xs text-slate-300">Optimiza la gestion compartiendo contexto y definiendo expectativas claras.</p>
+      <ul class="mt-4 space-y-3 text-xs">
+        <li class="flex items-start gap-2"><i data-lucide="info" class="mt-0.5 h-4 w-4 flex-none"></i><span>Incluye objetivos medibles en la descripcion para alinear expectativas.</span></li>
+        <li class="flex items-start gap-2"><i data-lucide="users" class="mt-0.5 h-4 w-4 flex-none"></i><span>Confirma la disponibilidad del director o estudiante antes de asignar.</span></li>
+        <li class="flex items-start gap-2"><i data-lucide="calendar" class="mt-0.5 h-4 w-4 flex-none"></i><span>Define hitos tempranamente para facilitar el seguimiento posterior.</span></li>
+      </ul>
     </section>
   </aside>
 </div>


### PR DESCRIPTION
## Summary
- add overview analytics, quick filters, and richer project cards plus guided creation flow in the projects module
- surface milestone distribution metrics, timeline styling, and improved submission/comment forms with actionable sidebar tips
- refresh the progress dashboard with a hero insight banner, status chips, upgraded project tiles, and actionable recommendations

## Testing
- php -l app/Views/projects/index.php
- php -l app/Views/milestones/index.php
- php -l app/Views/progress/index.php

------
https://chatgpt.com/codex/tasks/task_e_68dad9b41054832eb8b7091aad6fcc27