### PR TITLE
Improve Kanban layout in progress view

### DIFF
--- a/app/Views/progress/index.php
+++ b/app/Views/progress/index.php
@@ -17,6 +17,13 @@ $cardData = [
     ['label' => 'En revision', 'value' => $milestoneCounts['en_revision'] ?? 0, 'icon' => 'inbox'],
 ];
 
+$kanbanMeta = [
+    'pendiente' => ['title' => 'Por hacer', 'accent' => 'border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900'],
+    'en_progreso' => ['title' => 'En progreso', 'accent' => 'border-amber-200 bg-amber-50 dark:border-amber-500/40 dark:bg-amber-500/10'],
+    'en_revision' => ['title' => 'En revisión', 'accent' => 'border-sky-200 bg-sky-50 dark:border-sky-500/40 dark:bg-sky-500/10'],
+    'completado' => ['title' => 'Completado', 'accent' => 'border-emerald-200 bg-emerald-50 dark:border-emerald-500/40 dark:bg-emerald-500/10'],
+];
+
 ob_start();
 ?>
 <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
@@ -35,63 +42,104 @@ ob_start();
   <?php endforeach; ?>
 </div>
 
-<div class="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-[2fr,1fr]">
+<div class="mt-5 grid grid-cols-1 gap-4 xl:grid-cols-[2.1fr,1fr] xl:items-start">
   <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-    <header class="mb-4 flex items-center justify-between">
+    <header class="mb-4 flex flex-wrap items-end justify-between gap-3">
       <div>
-        <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Avance por proyecto</h2>
-        <p class="text-xs text-slate-500 dark:text-slate-400">Progreso calculado con base en hitos completados.</p>
+        <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Tablero Kanban de hitos</h2>
+        <p class="text-xs text-slate-500 dark:text-slate-400">Visualiza el flujo completo y detecta cuellos de botella entre columnas.</p>
       </div>
-      <div class="text-right text-xs text-slate-500 dark:text-slate-400">
-        <p class="uppercase tracking-wide text-[10px] text-slate-400">Tasa de finalizacion</p>
-        <p class="text-lg font-semibold text-slate-800 dark:text-slate-100"><?= $completionRate; ?>%</p>
+      <div class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300">
+        <p class="uppercase tracking-wide text-[10px] text-slate-400 dark:text-slate-500">Total de hitos</p>
+        <p class="text-sm font-semibold text-slate-700 dark:text-slate-200"><?= $milestoneCounts['total'] ?? 0; ?></p>
       </div>
     </header>
-
-    <?php if ($projectsProgress === []): ?>
-      <div class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 p-6 text-center text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/50">
-        Aun no hay hitos registrados en tus proyectos.
-      </div>
-    <?php else: ?>
-      <ul class="space-y-3">
-        <?php foreach ($projectsProgress as $project): ?>
-          <li class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 dark:border-slate-800 dark:bg-slate-900/70">
-            <div class="flex items-start justify-between gap-3">
-              <div>
-                <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100"><?= e($project['title']); ?></h3>
-                <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400">Estado: <?= e(ucwords(str_replace('_', ' ', $project['status']))); ?></p>
-              </div>
-              <p class="text-sm font-semibold text-slate-700 dark:text-slate-200"><?= $project['progress']; ?>%</p>
-            </div>
-            <div class="mt-3 h-2 w-full rounded-full bg-slate-200 dark:bg-slate-800">
-              <div class="h-full rounded-full bg-indigo-500 dark:bg-indigo-400" style="width: <?= $project['progress']; ?>%"></div>
-            </div>
-            <dl class="mt-2 flex flex-wrap gap-4 text-[11px] text-slate-500 dark:text-slate-400">
-              <div>
-                <dt class="uppercase tracking-wide text-[10px] text-slate-400">Hitos</dt>
-                <dd><?= $project['done']; ?>/<?= $project['total']; ?></dd>
-              </div>
-              <div>
-                <dt class="uppercase tracking-wide text-[10px] text-slate-400">En revision</dt>
-                <dd><?= $project['waiting_review']; ?></dd>
-              </div>
-            </dl>
-          </li>
-        <?php endforeach; ?>
-      </ul>
-    <?php endif; ?>
+    <div class="grid grid-cols-1 gap-3 md:grid-cols-2 2xl:grid-cols-4">
+      <?php foreach ($kanbanMeta as $status => $meta): ?>
+        <?php $items = $kanbanColumns[$status] ?? []; ?>
+        <div class="rounded-2xl border <?= $meta['accent']; ?> p-4">
+          <header class="flex items-center justify-between">
+            <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100"><?= e($meta['title']); ?></h3>
+            <span class="text-xs font-medium text-slate-500 dark:text-slate-400"><?= count($items); ?></span>
+          </header>
+          <?php if ($items === []): ?>
+            <p class="mt-3 rounded-xl border border-dashed border-slate-200 bg-white/60 px-3 py-3 text-xs text-slate-500 dark:border-slate-700 dark:bg-slate-900/40">
+              Sin hitos en esta columna.
+            </p>
+          <?php else: ?>
+            <ul class="mt-3 space-y-2">
+              <?php foreach ($items as $item): ?>
+                <li class="rounded-xl border border-slate-200 bg-white/90 px-3 py-2 text-xs shadow-sm dark:border-slate-700 dark:bg-slate-900/80">
+                  <p class="font-semibold text-slate-700 dark:text-slate-200"><?= e($item['title']); ?></p>
+                  <p class="text-[11px] text-slate-500 dark:text-slate-400"><?= e($item['project']); ?></p>
+                  <?php if (!empty($item['due_date'])): ?>
+                    <p class="mt-1 text-[11px] <?= !empty($item['overdue']) ? 'text-rose-500' : 'text-slate-500'; ?>">Entrega: <?= e($item['due_date']); ?><?= !empty($item['overdue']) ? ' (atrasado)' : ''; ?></p>
+                  <?php endif; ?>
+                </li>
+              <?php endforeach; ?>
+            </ul>
+          <?php endif; ?>
+        </div>
+      <?php endforeach; ?>
+    </div>
   </section>
 
   <aside class="space-y-4">
     <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Proximas entregas</h2>
-      <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Vencimientos dentro de los siguientes 7 dias.</p>
-      <?php if ($upcoming === []): ?>
-        <p class="mt-3 rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/50">Sin entregas proximas.</p>
+      <header class="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Avance por proyecto</h2>
+          <p class="text-xs text-slate-500 dark:text-slate-400">Progreso calculado con base en hitos completados.</p>
+        </div>
+        <div class="text-right text-xs text-slate-500 dark:text-slate-400">
+          <p class="uppercase tracking-wide text-[10px] text-slate-400">Tasa de finalizacion</p>
+          <p class="text-lg font-semibold text-slate-800 dark:text-slate-100"><?= $completionRate; ?>%</p>
+        </div>
+      </header>
+
+      <?php if ($projectsProgress === []): ?>
+        <div class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 p-6 text-center text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/50">
+          Aun no hay hitos registrados en tus proyectos.
+        </div>
       <?php else: ?>
-        <ul class="mt-3 space-y-2 text-xs text-slate-600 dark:text-slate-300">
+        <ul class="space-y-3">
+          <?php foreach ($projectsProgress as $project): ?>
+            <li class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 dark:border-slate-800 dark:bg-slate-900/70">
+              <div class="flex items-start justify-between gap-3">
+                <div>
+                  <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100"><?= e($project['title']); ?></h3>
+                  <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400">Estado: <?= e(ucwords(str_replace('_', ' ', $project['status']))); ?></p>
+                </div>
+                <p class="text-sm font-semibold text-slate-700 dark:text-slate-200"><?= $project['progress']; ?>%</p>
+              </div>
+              <div class="mt-3 h-2 w-full rounded-full bg-slate-200 dark:bg-slate-800">
+                <div class="h-full rounded-full bg-indigo-500 dark:bg-indigo-400" style="width: <?= $project['progress']; ?>%"></div>
+              </div>
+              <dl class="mt-2 flex flex-wrap gap-4 text-[11px] text-slate-500 dark:text-slate-400">
+                <div>
+                  <dt class="uppercase tracking-wide text-[10px] text-slate-400">Hitos</dt>
+                  <dd><?= $project['done']; ?>/<?= $project['total']; ?></dd>
+                </div>
+                <div>
+                  <dt class="uppercase tracking-wide text-[10px] text-slate-400">En revision</dt>
+                  <dd><?= $project['waiting_review']; ?></dd>
+                </div>
+              </dl>
+            </li>
+          <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
+    </section>
+
+    <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Próximas entregas</h2>
+      <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Vencimientos dentro de los siguientes 7 días.</p>
+      <?php if ($upcoming === []): ?>
+        <p class="mt-3 rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/50">Sin entregas próximas.</p>
+      <?php else: ?>
+        <ul class="mt-3 divide-y divide-slate-200 text-xs text-slate-600 dark:divide-slate-700 dark:text-slate-300">
           <?php foreach ($upcoming as $item): ?>
-            <li class="rounded-xl border border-slate-200 bg-white px-3 py-2 dark:border-slate-800 dark:bg-slate-900">
+            <li class="px-1 py-2">
               <p class="font-semibold text-slate-700 dark:text-slate-200"><?= e($item['title']); ?></p>
               <p class="text-[11px] text-slate-500 dark:text-slate-400"><?= e($item['project']); ?></p>
               <p class="mt-1 text-[11px] <?= $item['overdue'] ? 'text-rose-500' : 'text-slate-500'; ?>">Entrega: <?= e($item['due_date']); ?><?= $item['overdue'] ? ' (atrasado)' : ''; ?></p>
@@ -103,13 +151,13 @@ ob_start();
 
     <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Actividad reciente</h2>
-      <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Ultimos hitos marcados como completados.</p>
+      <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Últimos hitos marcados como completados.</p>
       <?php if ($recent === []): ?>
-        <p class="mt-3 rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/50">Aun no hay hitos completados recientemente.</p>
+        <p class="mt-3 rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/50">Aún no hay hitos completados recientemente.</p>
       <?php else: ?>
-        <ul class="mt-3 space-y-2 text-xs text-slate-600 dark:text-slate-300">
+        <ul class="mt-3 divide-y divide-slate-200 text-xs text-slate-600 dark:divide-slate-700 dark:text-slate-300">
           <?php foreach ($recent as $item): ?>
-            <li class="rounded-xl border border-slate-200 bg-white px-3 py-2 dark:border-slate-800 dark:bg-slate-900">
+            <li class="px-1 py-2">
               <p class="font-semibold text-slate-700 dark:text-slate-200"><?= e($item['title']); ?></p>
               <p class="text-[11px] text-slate-500 dark:text-slate-400"><?= e($item['project']); ?></p>
               <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400">Actualizado: <?= e(substr($item['updated_at'], 0, 16)); ?></p>

--- a/docs/review.md
+++ b/docs/review.md
@@ -1,0 +1,28 @@
+# Auditoría funcional del Gestor de Progreso de Titulación
+
+## Resumen de la arquitectura actual
+- **Autenticación y registro**: `AuthController` maneja inicio de sesión, registro, restablecimiento de contraseña y cierre de sesión con sesiones PHP y hashing seguro de contraseñas.【F:app/Controllers/AuthController.php†L1-L142】【F:app/Models/User.php†L42-L119】
+- **Gestión de proyectos**: `ProjectController` permite a estudiantes y directores crear proyectos asignando responsable y controlar el estado, respaldado por el modelo `Project` que crea la tabla y persiste la información.【F:app/Controllers/ProjectController.php†L1-L127】【F:app/Models/Project.php†L1-L109】
+- **Hitos, entregas y retroalimentación**: `MilestoneController` administra hitos, envíos de avances con archivos adjuntos y comentarios asociados a cada entrega; los modelos `Milestone`, `Submission` y `Comment` generan las tablas necesarias y encapsulan operaciones CRUD.【F:app/Controllers/MilestoneController.php†L1-L225】【F:app/Models/Milestone.php†L1-L93】【F:app/Models/Submission.php†L1-L87】【F:app/Models/Comment.php†L1-L80】
+- **Visualización del progreso**: `ProgressController` resume métricas globales de proyectos y próximos vencimientos para mostrar en la vista `progress/index.php`.【F:app/Controllers/ProgressController.php†L1-L99】【F:app/Views/progress/index.php†L1-L120】
+
+## Errores y riesgos detectados
+1. **Flujo de recuperación de contraseña inseguro**: `AuthController::requestPasswordChange` permite cambiar la contraseña con solo conocer el correo, sin enviar token de confirmación ni verificar propiedad vía correo electrónico, lo que abre la puerta a secuestro de cuentas si un actor conoce la dirección de correo institucional.【F:app/Controllers/AuthController.php†L89-L138】
+2. **Ausencia de límites de tamaño y validación de tipo MIME en archivos**: al subir entregables se valida la extensión, pero no el tamaño ni el tipo MIME real, por lo que podrían cargarse archivos muy grandes o con extensiones manipuladas que saturen el almacenamiento o supongan un riesgo de seguridad.【F:app/Controllers/MilestoneController.php†L117-L173】
+3. **Proyección incompleta de estados del proyecto en el tablero**: `ProgressController` y la vista de progreso asumen que todos los proyectos tienen estados definidos (`planeacion`, `en_progreso`, `en_revision`, `finalizado`); si en la base de datos se inserta otro estado (por ejemplo mediante migración futura o error manual), las métricas producirán índices indefinidos y una vista inconsistente.【F:app/Controllers/ProgressController.php†L35-L73】【F:app/Views/progress/index.php†L12-L44】
+
+## Requerimientos funcionales vs. implementación
+| Requerimiento | Estado actual | Observaciones |
+| --- | --- | --- |
+| Creación de proyectos estudiante ↔ director | ✅ Implementado mediante formularios diferenciados por rol y modelo `Project`. | Considerar reglas adicionales (p. ej. evitar duplicados) si el plan de titulación lo exige.【F:app/Controllers/ProjectController.php†L45-L124】 |
+| Definición de hitos y fechas | ✅ Habilitado en `MilestoneController::store` con campos de título, descripción y fecha límite. | Validación básica de fecha ya presente.【F:app/Controllers/MilestoneController.php†L65-L111】 |
+| Subida de avances (documentos/código) | ⚠️ Parcial: se permite adjuntar archivos pero falta controlar tamaño, validar MIME y mostrar historial con paginación para evitar cargas pesadas. | También sería útil informar tamaño máximo permitido al usuario.【F:app/Controllers/MilestoneController.php†L117-L188】 |
+| Feedback de los directores | ✅ Comentarios disponibles para la entrega más reciente y registro histórico por hito. | Podría habilitarse retroalimentación sobre entregas anteriores si se requiere.【F:app/Views/milestones/index.php†L73-L212】 |
+| Visualización del progreso (Kanban o Gantt simplificado) | ✅ Implementado con un tablero Kanban que agrupa los hitos por estado y resalta vencimientos próximos o atrasados directamente en la vista de progreso. | Mantener la consistencia de estados controlando los valores permitidos en BD y controladores.【F:app/Controllers/ProgressController.php†L47-L145】【F:app/Views/progress/index.php†L1-L170】 |
+
+## Recomendaciones para completar el proyecto
+1. **Diseñar módulo de visualización tipo Kanban/Gantt**: implementar una nueva vista que represente los hitos por estado (Kanban) o en un timeline (Gantt) reutilizando los datos de `MilestoneController` o extendiendo `ProgressController` para cubrir el requerimiento explícito.
+2. **Fortalecer la recuperación de contraseña**: introducir tokens firmados y expirables enviados por correo, de modo que el cambio solo sea posible tras confirmar la identidad del usuario.【F:app/Controllers/AuthController.php†L89-L138】
+3. **Validar archivos adjuntos en profundidad**: agregar límites de tamaño configurables y comprobar el MIME real (`finfo_file`) antes de guardar el archivo en `storage/uploads`. También convendría mostrar mensajes claros cuando un archivo exceda el límite.【F:app/Controllers/MilestoneController.php†L117-L173】
+4. **Gestionar estados de forma centralizada**: definir constantes/enums para los estados de proyectos e hitos que se usen tanto en BD como en controladores y vistas, evitando valores no contemplados y simplificando futuras extensiones.【F:app/Controllers/ProgressController.php†L35-L73】【F:app/Models/Project.php†L17-L64】
+5. **Documentar requisitos operativos**: añadir instrucciones en README sobre preparación de la base de datos SQLite/MySQL, permisos de la carpeta `storage/uploads` y variables de entorno necesarias para desplegar el sistema.【F:config/app.php†L1-L22】【F:app/Core/Database.php†L1-L51】


### PR DESCRIPTION
## Summary
- move the kanban board into the primary column so it can stretch wider and reorganize supporting sections to the sidebar
- enhance the kanban header with milestone totals and responsive column counts while keeping project progress, upcoming and recent lists accessible

## Testing
- php -l app/Views/progress/index.php

------
https://chatgpt.com/codex/tasks/task_e_68daf6a8878c832ebfa6152f2fb8db91