### PR TITLE
Enhance dashboard module styling

### DIFF
--- a/app/Views/dashboard/components/layout/head.php
+++ b/app/Views/dashboard/components/layout/head.php
@@ -18,9 +18,57 @@ $titleSuffix = isset($pageTitle) && $pageTitle ? 'Gestor de Titulación - ' . $p
     };
   </script>
   <style>
+    body {
+      background-color: #f8fafc;
+      background-image:
+        radial-gradient(120% 120% at -10% -10%, rgba(129, 140, 248, 0.18), transparent 55%),
+        radial-gradient(70% 100% at 110% -10%, rgba(45, 212, 191, 0.12), transparent 55%),
+        radial-gradient(90% 140% at 50% 120%, rgba(59, 130, 246, 0.1), transparent 65%);
+      background-attachment: fixed;
+    }
+
+    .dark body {
+      background-color: rgb(2 6 23);
+      background-image:
+        radial-gradient(120% 120% at -10% -10%, rgba(59, 130, 246, 0.2), transparent 55%),
+        radial-gradient(80% 120% at 110% -10%, rgba(8, 145, 178, 0.24), transparent 60%),
+        radial-gradient(100% 140% at 50% 120%, rgba(129, 140, 248, 0.2), transparent 70%);
+    }
+
     .transition-width { transition: width .3s ease; }
     .scrollbar-thin { scrollbar-width: thin; }
     .scrollbar-thin::-webkit-scrollbar { width: 6px; }
     .scrollbar-thin::-webkit-scrollbar-thumb { background-color: rgba(148, 163, 184, .6); border-radius: 9999px; }
+
+    .glass-card {
+      background-color: rgba(255, 255, 255, 0.82);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      box-shadow: 0 25px 40px -30px rgba(15, 23, 42, 0.55);
+      backdrop-filter: blur(18px);
+    }
+
+    .dark .glass-card {
+      background-color: rgba(15, 23, 42, 0.7);
+      border-color: rgba(71, 85, 105, 0.45);
+      box-shadow: 0 25px 40px -25px rgba(15, 23, 42, 0.85);
+    }
+
+    .glow-accent::before {
+      content: "";
+      position: absolute;
+      inset-inline-end: -40px;
+      inset-block-start: -40px;
+      width: 180px;
+      height: 180px;
+      border-radius: 9999px;
+      background: radial-gradient(circle, rgba(255, 255, 255, 0.55), transparent 65%);
+      opacity: .75;
+      filter: blur(0);
+    }
+
+    .dark .glow-accent::before {
+      background: radial-gradient(circle, rgba(99, 102, 241, 0.55), transparent 65%);
+      opacity: .65;
+    }
   </style>
 </head>

--- a/app/Views/dashboard/components/layout/main.php
+++ b/app/Views/dashboard/components/layout/main.php
@@ -1,11 +1,13 @@
 <?php $_dashboard = get_defined_vars(); ?>
-<main class="min-h-[calc(100vh-3.5rem)] flex-1 p-3 sm:p-6">
-  <?php dashboard_layout('page-heading', $_dashboard); ?>
-  <?php dashboard_component('shared/alerts', $_dashboard); ?>
+<main class="relative min-h-[calc(100vh-3.5rem)] flex-1 p-4 sm:p-8">
+  <div class="mx-auto flex w-full max-w-7xl flex-col gap-8">
+    <?php dashboard_layout('page-heading', $_dashboard); ?>
+    <?php dashboard_component('shared/alerts', $_dashboard); ?>
 
-  <?php dashboard_section('dashboard-overview', $_dashboard); ?>
-  <?php dashboard_section('projects', $_dashboard); ?>
-  <?php dashboard_section('milestones', $_dashboard); ?>
-  <?php dashboard_section('comments', $_dashboard); ?>
-  <?php dashboard_section('progress', $_dashboard); ?>
+    <?php dashboard_section('dashboard-overview', $_dashboard); ?>
+    <?php dashboard_section('projects', $_dashboard); ?>
+    <?php dashboard_section('milestones', $_dashboard); ?>
+    <?php dashboard_section('comments', $_dashboard); ?>
+    <?php dashboard_section('progress', $_dashboard); ?>
+  </div>
 </main>

--- a/app/Views/dashboard/components/layout/page-heading.php
+++ b/app/Views/dashboard/components/layout/page-heading.php
@@ -1,7 +1,35 @@
-<div class="mb-4 flex flex-wrap items-center justify-between gap-3">
-  <div>
-    <h1 id="pageTitle" class="text-xl font-semibold sm:text-2xl"><?= e($pageTitle ?? 'Panel'); ?></h1>
-    <p id="pageSubtitle" class="mt-0.5 text-xs text-slate-500 dark:text-slate-400"><?= e($pageSubtitle ?? 'Resumen general y acciones rápidas'); ?></p>
+<?php
+$totalProjects = count($projects ?? []);
+$upcoming = count($upcomingMilestones ?? []);
+$activeProjects = $stats['active'] ?? null;
+?>
+<div class="relative overflow-hidden rounded-3xl bg-gradient-to-br from-indigo-500 via-sky-500 to-purple-600 px-6 py-7 text-white shadow-xl glow-accent">
+  <div class="flex flex-wrap items-start justify-between gap-6">
+    <div class="max-w-xl">
+      <p class="text-[11px] uppercase tracking-[0.2em] text-white/70">Panel de control</p>
+      <h1 id="pageTitle" class="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
+        <?= e($pageTitle ?? 'Panel'); ?>
+      </h1>
+      <p id="pageSubtitle" class="mt-2 text-sm text-white/80">
+        <?= e($pageSubtitle ?? 'Resumen general y acciones rápidas'); ?>
+      </p>
+    </div>
+
+    <div class="flex flex-col gap-2 text-xs sm:text-sm">
+      <div class="inline-flex items-center gap-2 rounded-full bg-white/15 px-4 py-2 backdrop-blur">
+        <i data-lucide="rocket" class="h-4 w-4"></i>
+        <span class="font-medium">Proyectos activos: <?= e((string) ($activeProjects ?? '--')); ?></span>
+      </div>
+      <div class="inline-flex items-center gap-2 rounded-full bg-white/15 px-4 py-2 backdrop-blur">
+        <i data-lucide="folders" class="h-4 w-4"></i>
+        <span class="font-medium">Totales: <?= e((string) $totalProjects); ?></span>
+      </div>
+      <div class="inline-flex items-center gap-2 rounded-full bg-white/15 px-4 py-2 backdrop-blur">
+        <i data-lucide="calendar-clock" class="h-4 w-4"></i>
+        <span class="font-medium">Hitos próximos: <?= e((string) $upcoming); ?></span>
+      </div>
+    </div>
   </div>
+
   <form method="post" action="<?= e(url('/logout')); ?>" id="logoutForm" class="hidden"></form>
 </div>

--- a/app/Views/dashboard/components/sections/comments.php
+++ b/app/Views/dashboard/components/sections/comments.php
@@ -1,23 +1,26 @@
 <?php $isCommentsActive = ($activeTab ?? 'dashboard') === 'comentarios'; ?>
-<section id="section-comentarios" data-section="comentarios" class="mt-8 space-y-6<?= $isCommentsActive ? '' : ' hidden'; ?>">
-  <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+<section id="section-comentarios" data-section="comentarios" class="flex flex-col gap-6<?= $isCommentsActive ? '' : ' hidden'; ?>">
+  <article class="rounded-3xl glass-card p-6 shadow-xl">
     <div class="space-y-4">
       <?php if ($projectMilestones === []): ?>
-        <p class="text-sm text-slate-500">Selecciona un proyecto con hitos para ver los comentarios.</p>
+        <p class="rounded-2xl border border-dashed border-slate-200/70 bg-white/60 px-4 py-6 text-center text-sm text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/40">Selecciona un proyecto con hitos para ver los comentarios.</p>
       <?php else: ?>
         <?php foreach ($projectMilestones as $milestone): ?>
           <?php $feedbackList = $feedbackByMilestone[$milestone['id']] ?? []; ?>
-          <section class="rounded-xl border border-slate-200 bg-white/80 p-4 dark:border-slate-800 dark:bg-slate-900/40">
+          <section class="rounded-3xl border border-slate-200/60 bg-white/70 p-5 shadow-sm dark:border-slate-800/60 dark:bg-slate-900/50">
             <div class="flex items-center justify-between">
               <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Hito: <?= e($milestone['title']); ?></h3>
-              <span class="rounded-lg bg-slate-100 px-2 py-0.5 text-[11px] text-slate-500 dark:bg-slate-800">Comentarios: <?= e((string) count($feedbackList)); ?></span>
+              <span class="inline-flex items-center gap-1 rounded-full bg-slate-500/10 px-3 py-0.5 text-[11px] font-semibold text-slate-600 dark:bg-slate-700/40 dark:text-slate-200">
+                <i data-lucide="chat" class="h-3.5 w-3.5"></i>
+                Comentarios: <?= e((string) count($feedbackList)); ?>
+              </span>
             </div>
             <div class="mt-3 space-y-3">
               <?php if ($feedbackList === []): ?>
-                <p class="text-xs text-slate-500">Sin comentarios registrados.</p>
+                <p class="rounded-2xl border border-dashed border-slate-200/70 bg-white/60 px-3 py-4 text-center text-xs text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/40">Sin comentarios registrados.</p>
               <?php else: ?>
                 <?php foreach ($feedbackList as $comment): ?>
-                  <article class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                  <article class="rounded-2xl border border-slate-200/60 bg-white/80 px-4 py-3 text-sm shadow-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800/60 dark:bg-slate-900/60">
                     <div class="flex items-center justify-between text-xs text-slate-400">
                       <span class="font-semibold text-slate-600 dark:text-slate-200"><?= e($comment['author_name']); ?></span>
                       <span><?= e(format_dashboard_date($comment['created_at'] ?? null)); ?></span>

--- a/app/Views/dashboard/components/sections/dashboard-overview.php
+++ b/app/Views/dashboard/components/sections/dashboard-overview.php
@@ -5,59 +5,68 @@ $statCards = [
         'label' => 'Proyectos totales',
         'value' => $stats['total'] ?? 0,
         'icon' => 'layers',
-        'accent' => 'text-indigo-500',
+        'icon_color' => 'text-indigo-500',
+        'gradient' => 'from-indigo-500/35 via-indigo-500/10 to-transparent',
     ],
     [
         'label' => 'Activos',
         'value' => $stats['active'] ?? 0,
         'icon' => 'activity',
-        'accent' => 'text-emerald-500',
+        'icon_color' => 'text-emerald-500',
+        'gradient' => 'from-emerald-400/35 via-emerald-400/10 to-transparent',
     ],
     [
         'label' => 'Completados',
         'value' => $stats['completed'] ?? 0,
         'icon' => 'check-circle',
-        'accent' => 'text-emerald-500',
+        'icon_color' => 'text-sky-500',
+        'gradient' => 'from-sky-400/35 via-sky-400/10 to-transparent',
     ],
     [
         'label' => 'Vencen pronto (7 días)',
         'value' => $stats['due_soon'] ?? 0,
         'icon' => 'clock',
-        'accent' => 'text-amber-500',
+        'icon_color' => 'text-amber-500',
+        'gradient' => 'from-amber-400/35 via-amber-400/10 to-transparent',
     ],
 ];
 ?>
-<section id="section-dashboard" data-section="dashboard" class="space-y-6<?= $isDashboardActive ? '' : ' hidden'; ?>">
-  <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+<section id="section-dashboard" data-section="dashboard" class="flex flex-col gap-6<?= $isDashboardActive ? '' : ' hidden'; ?>">
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
     <?php foreach ($statCards as $card): ?>
-      <article class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-        <div class="flex items-center justify-between">
-          <p class="text-xs font-medium uppercase tracking-wide text-slate-500"><?= e($card['label']); ?></p>
-          <i data-lucide="<?= e($card['icon']); ?>" class="h-5 w-5 <?= e($card['accent']); ?>"></i>
+      <article class="relative overflow-hidden rounded-3xl glass-card p-5 transition-transform duration-300 ease-out hover:-translate-y-1 hover:shadow-2xl">
+        <div class="pointer-events-none absolute inset-0 bg-gradient-to-br <?= e($card['gradient']); ?> opacity-90"></div>
+        <div class="relative z-[1] flex flex-col gap-4">
+          <div class="flex items-center justify-between">
+            <p class="text-xs font-medium uppercase tracking-wide text-slate-600 dark:text-slate-300/80"><?= e($card['label']); ?></p>
+            <span class="inline-flex rounded-2xl bg-white/60 p-2 text-slate-600 shadow-sm dark:bg-slate-900/60">
+              <i data-lucide="<?= e($card['icon']); ?>" class="h-5 w-5 <?= e($card['icon_color']); ?>"></i>
+            </span>
+          </div>
+          <p class="text-3xl font-semibold text-slate-900 dark:text-white"><?= e((string) $card['value']); ?></p>
         </div>
-        <p class="mt-4 text-3xl font-semibold"><?= e((string) $card['value']); ?></p>
       </article>
     <?php endforeach; ?>
   </div>
 
-  <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
-    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+  <div class="grid grid-cols-1 gap-5 xl:grid-cols-2">
+    <article class="rounded-3xl glass-card p-6 shadow-lg">
       <div class="flex items-center justify-between">
-        <h2 class="text-base font-semibold">Próximos hitos</h2>
-        <span class="text-xs text-slate-500"><?= e((string) count($upcomingMilestones)); ?> pendientes</span>
+        <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Próximos hitos</h2>
+        <span class="text-xs font-medium text-slate-500 dark:text-slate-400"><?= e((string) count($upcomingMilestones)); ?> pendientes</span>
       </div>
-      <div class="mt-4 space-y-3">
+      <div class="mt-5 space-y-3">
         <?php if ($upcomingMilestones === []): ?>
-          <p class="text-sm text-slate-500">Sin hitos programados en los próximos días.</p>
+          <p class="rounded-2xl border border-dashed border-slate-200/70 bg-white/60 px-4 py-6 text-center text-sm text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/50">Sin hitos programados en los próximos días.</p>
         <?php else: ?>
           <?php foreach ($upcomingMilestones as $item): ?>
-            <div class="rounded-xl border border-slate-200/70 bg-slate-50 px-3 py-3 text-sm dark:border-slate-800 dark:bg-slate-900">
+            <div class="rounded-2xl border border-white/70 bg-white/70 px-4 py-3 text-sm shadow-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md dark:border-slate-700/60 dark:bg-slate-900/60">
               <div class="flex items-center justify-between gap-3">
                 <div>
                   <p class="font-medium text-slate-800 dark:text-slate-100"><?= e($item['title']); ?></p>
                   <p class="text-xs text-slate-500">Proyecto: <?= e($item['project_title']); ?></p>
                 </div>
-                <span class="rounded-lg bg-indigo-100 px-2 py-1 text-[11px] font-medium text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-200">
+                <span class="inline-flex items-center rounded-full bg-indigo-500/15 px-3 py-1 text-[11px] font-semibold text-indigo-600 dark:bg-indigo-500/30 dark:text-indigo-200">
                   <?= e(format_dashboard_date($item['due_date'] ?? null)); ?>
                 </span>
               </div>
@@ -67,17 +76,17 @@ $statCards = [
       </div>
     </article>
 
-    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <article class="rounded-3xl glass-card p-6 shadow-lg">
       <div class="flex items-center justify-between">
-        <h2 class="text-base font-semibold">Feedback reciente</h2>
-        <span class="text-xs text-slate-500"><?= e((string) count($recentFeedback)); ?> registros</span>
+        <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Feedback reciente</h2>
+        <span class="text-xs font-medium text-slate-500 dark:text-slate-400"><?= e((string) count($recentFeedback)); ?> registros</span>
       </div>
-      <div class="mt-4 space-y-3">
+      <div class="mt-5 space-y-3">
         <?php if ($recentFeedback === []): ?>
-          <p class="text-sm text-slate-500">Aún no hay comentarios registrados.</p>
+          <p class="rounded-2xl border border-dashed border-slate-200/70 bg-white/60 px-4 py-6 text-center text-sm text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/50">Aún no hay comentarios registrados.</p>
         <?php else: ?>
           <?php foreach ($recentFeedback as $comment): ?>
-            <div class="rounded-xl border border-slate-200/70 px-3 py-3 text-sm dark:border-slate-800">
+            <div class="rounded-2xl border border-white/70 bg-white/70 px-4 py-3 text-sm shadow-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md dark:border-slate-700/60 dark:bg-slate-900/60">
               <div class="flex items-center justify-between gap-2">
                 <p class="font-medium text-slate-800 dark:text-slate-100">
                   <?= e($comment['author_name']); ?>

--- a/app/Views/dashboard/components/sections/milestones.php
+++ b/app/Views/dashboard/components/sections/milestones.php
@@ -1,22 +1,25 @@
 <?php $isMilestonesActive = ($activeTab ?? 'dashboard') === 'hitos'; ?>
-<section id="section-hitos" data-section="hitos" class="mt-8 space-y-6<?= $isMilestonesActive ? '' : ' hidden'; ?>">
+<section id="section-hitos" data-section="hitos" class="flex flex-col gap-6<?= $isMilestonesActive ? '' : ' hidden'; ?>">
   <?php if (!$selectedProject): ?>
-    <div class="rounded-2xl border border-slate-200 bg-white px-5 py-10 text-center text-sm text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="glass-card px-6 py-12 text-center text-sm text-slate-500 shadow-xl dark:text-slate-400">
       Selecciona un proyecto para gestionar sus hitos.
     </div>
   <?php else: ?>
-    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <article class="rounded-3xl glass-card p-6 shadow-xl">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h3 class="text-base font-semibold text-slate-800 dark:text-slate-100"><?= e($selectedProject['title']); ?></h3>
-          <p class="text-xs text-slate-500">Estudiante: <?= e($selectedProject['student_name']); ?> · Director: <?= e($selectedProject['director_name']); ?></p>
+          <p class="text-xs text-slate-500 dark:text-slate-400">Estudiante: <?= e($selectedProject['student_name']); ?> · Director: <?= e($selectedProject['director_name']); ?></p>
         </div>
-        <span class="rounded-lg px-3 py-1 text-xs font-semibold <?= e(status_badge_classes($selectedProject['status'])); ?>">Estado: <?= e(humanize_status($selectedProject['status'])); ?></span>
+        <span class="inline-flex items-center gap-2 rounded-full bg-white/60 px-4 py-1 text-xs font-semibold text-slate-600 shadow-sm dark:bg-slate-900/60 dark:text-slate-200">
+          <i data-lucide="sparkles" class="h-3.5 w-3.5"></i>
+          Estado: <span class="rounded-full px-2 py-0.5 <?= e(status_badge_classes($selectedProject['status'])); ?>"><?= e(humanize_status($selectedProject['status'])); ?></span>
+        </span>
       </div>
 
       <div class="mt-6 space-y-4">
         <?php if ($projectMilestones === []): ?>
-          <div class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900/40">Aún no hay hitos registrados.</div>
+          <div class="rounded-2xl border border-dashed border-slate-200/70 bg-white/60 px-5 py-8 text-center text-sm text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/40">Aún no hay hitos registrados.</div>
         <?php else: ?>
           <?php foreach ($projectMilestones as $milestone): ?>
             <?php
@@ -35,25 +38,28 @@
               $canUploadDeliverable = !empty($isStudentOwner)
                   && !in_array($milestone['status'], ['en_revision', 'aprobado'], true);
             ?>
-            <article class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/60">
+            <article class="rounded-3xl border border-slate-200/60 bg-white/70 p-5 shadow-md transition duration-200 hover:-translate-y-0.5 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60">
               <div class="flex flex-wrap items-start justify-between gap-3">
                 <div>
                   <h4 class="text-sm font-semibold text-slate-800 dark:text-slate-100"><?= e($milestone['title']); ?></h4>
-                  <p class="mt-1 text-xs text-slate-500"><?= e($milestone['description'] ?: 'Sin descripción.'); ?></p>
-                  <p class="mt-2 text-xs text-slate-400">Entrega: <?= e(format_dashboard_date($milestone['due_date'] ?? null)); ?></p>
+                  <p class="mt-1 text-xs text-slate-500 dark:text-slate-400"><?= e($milestone['description'] ?: 'Sin descripción.'); ?></p>
+                  <p class="mt-2 inline-flex items-center gap-1 rounded-full bg-indigo-500/10 px-3 py-1 text-[11px] font-medium text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-200">
+                    <i data-lucide="calendar" class="h-3.5 w-3.5"></i>
+                    Entrega: <?= e(format_dashboard_date($milestone['due_date'] ?? null)); ?>
+                  </p>
                 </div>
                 <div class="flex flex-wrap items-center gap-2">
-                  <span class="rounded-lg px-2 py-1 text-[11px] font-semibold <?= e(status_badge_classes($milestone['status'])); ?>"><?= e(humanize_status($milestone['status'])); ?></span>
+                  <span class="rounded-full px-3 py-1 text-[11px] font-semibold <?= e(status_badge_classes($milestone['status'])); ?>"><?= e(humanize_status($milestone['status'])); ?></span>
                   <?php if ($statusOptions !== []): ?>
                     <form method="post" action="<?= e(url('/milestones/status')); ?>" class="flex items-center gap-1">
                       <input type="hidden" name="milestone_id" value="<?= e((string) $milestone['id']); ?>" />
                       <label class="sr-only" for="milestone-status-<?= e((string) $milestone['id']); ?>">Estado</label>
-                      <select id="milestone-status-<?= e((string) $milestone['id']); ?>" name="status" class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs outline-none dark:border-slate-700 dark:bg-slate-900">
+                      <select id="milestone-status-<?= e((string) $milestone['id']); ?>" name="status" class="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs outline-none transition focus:border-indigo-500 dark:border-slate-700/60 dark:bg-slate-900">
                         <?php foreach ($statusOptions as $option): ?>
                           <option value="<?= e($option); ?>" <?= $option === ($milestone['status'] ?? '') ? 'selected' : ''; ?>><?= e(humanize_status($option)); ?></option>
                         <?php endforeach; ?>
                       </select>
-                      <button type="submit" class="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-700">
+                      <button type="submit" class="inline-flex items-center gap-1 rounded-full bg-indigo-600 px-3 py-1 text-xs font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-indigo-700">
                         <i data-lucide="save" class="h-3.5 w-3.5"></i>
                       </button>
                     </form>
@@ -61,32 +67,33 @@
                 </div>
               </div>
 
-              <div class="mt-4 grid gap-4 lg:grid-cols-2">
-                <section class="rounded-lg border border-slate-200 bg-slate-50 p-4 text-xs dark:border-slate-800 dark:bg-slate-900/40">
+              <div class="mt-5 grid gap-4 lg:grid-cols-2">
+                <section class="rounded-2xl border border-slate-200/60 bg-white/70 p-4 text-xs shadow-sm dark:border-slate-800/60 dark:bg-slate-950/40">
                   <div class="flex items-center justify-between">
                     <p class="font-semibold text-slate-700 dark:text-slate-200">Entregables</p>
-                    <span class="rounded-lg bg-indigo-100 px-2 py-0.5 text-[11px] font-semibold text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-200">
+                    <span class="inline-flex items-center gap-1 rounded-full bg-indigo-500/10 px-3 py-0.5 text-[11px] font-semibold text-indigo-600 dark:bg-indigo-500/30 dark:text-indigo-200">
+                      <i data-lucide="file-check" class="h-3.5 w-3.5"></i>
                       <?= e((string) ($milestone['deliverables_count'] ?? 0)); ?>
                     </span>
                   </div>
                   <div class="mt-3 max-h-40 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
                     <?php if ($deliverables === []): ?>
-                      <p class="text-slate-500">Sin entregas aún.</p>
+                      <p class="text-slate-500 dark:text-slate-400">Sin entregas aún.</p>
                     <?php else: ?>
                       <?php foreach ($deliverables as $deliverable): ?>
-                        <article class="rounded-lg bg-white/80 px-3 py-2 shadow-sm ring-1 ring-slate-200 dark:bg-slate-950/30 dark:ring-slate-800">
+                        <article class="rounded-2xl border border-slate-200/60 bg-white/80 px-3 py-2 shadow-sm dark:border-slate-800/60 dark:bg-slate-950/40">
                           <p class="text-slate-700 dark:text-slate-200"><?= e($deliverable['original_name']); ?></p>
                           <p class="text-[11px] text-slate-400">Autor: <?= e($deliverable['author_name']); ?></p>
                           <div class="mt-1 flex items-center justify-between text-[11px] text-slate-400">
                             <span><?= e($deliverable['notes'] ? 'Notas incluidas' : 'Archivo'); ?></span>
                             <?php if (!empty($deliverable['file_path'])): ?>
-                              <a class="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-0.5 text-[11px] text-indigo-600 hover:bg-indigo-50 dark:border-slate-700 dark:text-indigo-300 dark:hover:bg-indigo-900/40" href="<?= e(url('/deliverables/download?id=' . (int) $deliverable['id'])); ?>">
+                              <a class="inline-flex items-center gap-1 rounded-full border border-indigo-500/30 px-2.5 py-0.5 text-[11px] font-medium text-indigo-600 transition hover:-translate-y-0.5 hover:bg-indigo-50 dark:border-indigo-500/40 dark:text-indigo-200 dark:hover:bg-indigo-500/20" href="<?= e(url('/deliverables/download?id=' . (int) $deliverable['id'])); ?>">
                                 <i data-lucide="download" class="h-3 w-3"></i> Descargar
                               </a>
                             <?php endif; ?>
                           </div>
                           <?php if (!empty($deliverable['notes'])): ?>
-                            <p class="mt-2 rounded-lg bg-slate-100 px-2 py-1 text-slate-600 dark:bg-slate-800 dark:text-slate-200">"<?= e($deliverable['notes']); ?>"</p>
+                            <p class="mt-2 rounded-2xl bg-slate-100/80 px-3 py-1.5 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">"<?= e($deliverable['notes']); ?>"</p>
                           <?php endif; ?>
                         </article>
                       <?php endforeach; ?>
@@ -95,34 +102,35 @@
 
                   <div class="mt-3">
                     <?php if ($canUploadDeliverable): ?>
-                      <form method="post" action="<?= e(url('/deliverables')); ?>" enctype="multipart/form-data" class="space-y-2">
+                      <form method="post" action="<?= e(url('/deliverables')); ?>" enctype="multipart/form-data" class="space-y-3">
                         <input type="hidden" name="milestone_id" value="<?= e((string) $milestone['id']); ?>" />
                         <label class="block text-[11px] font-semibold uppercase text-slate-500">Subir avance</label>
-                        <input type="file" name="file" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs dark:border-slate-700 dark:bg-slate-900" />
-                        <textarea name="notes" rows="2" placeholder="Notas complementarias (opcional)" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900"></textarea>
-                        <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3 py-2 text-xs font-medium text-white hover:bg-indigo-700">
+                        <input type="file" name="file" class="w-full rounded-2xl border border-slate-200/80 bg-white px-3 py-2 text-xs transition focus:border-indigo-500 dark:border-slate-700/60 dark:bg-slate-900" />
+                        <textarea name="notes" rows="2" placeholder="Notas complementarias (opcional)" class="w-full rounded-2xl border border-slate-200/80 bg-white px-3 py-2 text-xs outline-none transition focus:border-indigo-500 dark:border-slate-700/60 dark:bg-slate-900"></textarea>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-indigo-700">
                           <i data-lucide="upload" class="h-3.5 w-3.5"></i> Registrar avance
                         </button>
                       </form>
                     <?php else: ?>
-                      <p class="text-[11px] text-slate-500">Solo el estudiante puede registrar avances antes de enviar a revisión o después de aprobación.</p>
+                      <p class="text-[11px] text-slate-500 dark:text-slate-400">Solo el estudiante puede registrar avances antes de enviar a revisión o después de aprobación.</p>
                     <?php endif; ?>
                   </div>
                 </section>
 
-                <section class="rounded-lg border border-slate-200 bg-slate-50 p-4 text-xs dark:border-slate-800 dark:bg-slate-900/40">
+                <section class="rounded-2xl border border-slate-200/60 bg-white/70 p-4 text-xs shadow-sm dark:border-slate-800/60 dark:bg-slate-950/40">
                   <div class="flex items-center justify-between">
                     <p class="font-semibold text-slate-700 dark:text-slate-200">Feedback</p>
-                    <span class="rounded-lg bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 dark:bg-emerald-900/60 dark:text-emerald-200">
+                    <span class="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-0.5 text-[11px] font-semibold text-emerald-600 dark:bg-emerald-500/30 dark:text-emerald-200">
+                      <i data-lucide="message-circle" class="h-3.5 w-3.5"></i>
                       <?= e((string) ($milestone['feedback_count'] ?? 0)); ?>
                     </span>
                   </div>
                   <div class="mt-3 max-h-40 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
                     <?php if ($feedbackList === []): ?>
-                      <p class="text-slate-500">Sin comentarios aún.</p>
+                      <p class="text-slate-500 dark:text-slate-400">Sin comentarios aún.</p>
                     <?php else: ?>
                       <?php foreach ($feedbackList as $comment): ?>
-                        <article class="rounded-lg bg-white/80 px-3 py-2 shadow-sm ring-1 ring-slate-200 dark:bg-slate-950/30 dark:ring-slate-800">
+                        <article class="rounded-2xl border border-slate-200/60 bg-white/80 px-3 py-2 shadow-sm dark:border-slate-800/60 dark:bg-slate-950/40">
                           <p class="font-semibold text-slate-700 dark:text-slate-200"><?= e($comment['author_name']); ?></p>
                           <p class="mt-1 text-slate-600 dark:text-slate-300">"<?= e($comment['content']); ?>"</p>
                         </article>
@@ -132,8 +140,8 @@
                   <div class="mt-3">
                     <form method="post" action="<?= e(url('/feedback')); ?>" class="space-y-2">
                       <input type="hidden" name="milestone_id" value="<?= e((string) $milestone['id']); ?>" />
-                      <textarea name="content" rows="3" placeholder="Escribe un comentario" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900" required></textarea>
-                      <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3 py-2 text-xs font-medium text-white hover:bg-emerald-700">
+                      <textarea name="content" rows="3" placeholder="Escribe un comentario" class="w-full rounded-2xl border border-slate-200/80 bg-white px-3 py-2 text-xs outline-none transition focus:border-emerald-500 dark:border-slate-700/60 dark:bg-slate-900" required></textarea>
+                      <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-emerald-700">
                         <i data-lucide="message-circle" class="h-3.5 w-3.5"></i> Enviar feedback
                       </button>
                     </form>

--- a/app/Views/dashboard/components/sections/progress.php
+++ b/app/Views/dashboard/components/sections/progress.php
@@ -7,26 +7,30 @@ $boardMap = [
     'aprobado' => 'Aprobado',
 ];
 ?>
-<section id="section-progreso" data-section="progreso" class="mt-8 space-y-6<?= $isProgressActive ? '' : ' hidden'; ?>">
-  <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+<section id="section-progreso" data-section="progreso" class="flex flex-col gap-6<?= $isProgressActive ? '' : ' hidden'; ?>">
+  <div class="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-4">
     <?php foreach ($boardMap as $columnKey => $columnLabel): ?>
       <?php $items = $boardColumns[$columnKey] ?? []; ?>
-      <article class="flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <article class="flex h-full flex-col rounded-3xl glass-card p-5 shadow-xl">
         <div class="flex items-center justify-between">
           <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-200"><?= e($columnLabel); ?></h3>
-          <span class="rounded-lg bg-slate-100 px-2 py-0.5 text-[11px] text-slate-500 dark:bg-slate-800">
+          <span class="inline-flex items-center gap-1 rounded-full bg-slate-500/10 px-3 py-0.5 text-[11px] font-semibold text-slate-600 dark:bg-slate-700/40 dark:text-slate-200">
+            <i data-lucide="kanban" class="h-3.5 w-3.5"></i>
             <?= e((string) count($items)); ?>
           </span>
         </div>
-        <div class="mt-3 flex-1 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
+        <div class="mt-4 flex-1 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
           <?php if ($items === []): ?>
-            <p class="text-xs text-slate-500">Sin elementos.</p>
+            <p class="rounded-2xl border border-dashed border-slate-200/70 bg-white/60 px-3 py-4 text-center text-xs text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/40">Sin elementos.</p>
           <?php else: ?>
             <?php foreach ($items as $item): ?>
-              <article class="rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs dark:border-slate-800 dark:bg-slate-900/50">
+              <article class="rounded-2xl border border-slate-200/60 bg-white/80 p-3 text-xs shadow-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800/60 dark:bg-slate-900/60">
                 <p class="font-semibold text-slate-700 dark:text-slate-100"><?= e($item['title']); ?></p>
                 <p class="mt-1 text-[11px] text-slate-500">Proyecto: <?= e($item['project_title']); ?></p>
-                <p class="mt-2 text-[11px] text-slate-400">Entrega: <?= e(format_dashboard_date($item['due_date'] ?? null)); ?></p>
+                <p class="mt-2 inline-flex items-center gap-1 rounded-full bg-indigo-500/10 px-2.5 py-1 text-[11px] font-medium text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-200">
+                  <i data-lucide="alarm-clock" class="h-3 w-3"></i>
+                  <?= e(format_dashboard_date($item['due_date'] ?? null)); ?>
+                </p>
               </article>
             <?php endforeach; ?>
           <?php endif; ?>

--- a/app/Views/dashboard/components/sections/projects.php
+++ b/app/Views/dashboard/components/sections/projects.php
@@ -1,64 +1,70 @@
 <?php $isProjectsActive = ($activeTab ?? 'dashboard') === 'proyectos'; ?>
-<section id="section-proyectos" data-section="proyectos" class="mt-8 space-y-6<?= $isProjectsActive ? '' : ' hidden'; ?>">
-  <div class="flex flex-wrap items-center justify-end gap-3">
+<section id="section-proyectos" data-section="proyectos" class="flex flex-col gap-5<?= $isProjectsActive ? '' : ' hidden'; ?>">
+  <div class="flex flex-wrap items-center justify-between gap-4">
+    <div class="max-w-2xl">
+      <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Gestión de proyectos</h2>
+      <p class="text-sm text-slate-500 dark:text-slate-400">Administra los equipos, estados y fechas de entrega desde un panel más claro y moderno.</p>
+    </div>
     <?php if (!empty($isDirector)): ?>
-      <button data-modal="modalProject" type="button" class="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 focus:outline-none">
-        <i data-lucide="plus" class="h-4 w-4"></i> Nuevo proyecto
+      <button data-modal="modalProject" type="button" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-indigo-500 via-indigo-600 to-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-lg transition duration-200 hover:-translate-y-0.5 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-indigo-400/60">
+        <i data-lucide="plus" class="h-4 w-4"></i>
+        Nuevo proyecto
       </button>
     <?php endif; ?>
   </div>
 
-  <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-    <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
-      <thead class="bg-slate-50 dark:bg-slate-900/70">
-        <tr class="text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
-          <th class="px-4 py-3">Proyecto</th>
-          <th class="px-4 py-3">Estudiante</th>
-          <th class="px-4 py-3">Estado</th>
-          <th class="px-4 py-3">Entrega</th>
-          <th class="px-4 py-3 text-right">Acciones</th>
+  <div class="overflow-hidden rounded-3xl glass-card shadow-xl">
+    <table class="min-w-full divide-y divide-slate-200/60 text-sm dark:divide-slate-800/60">
+      <thead class="bg-white/40 backdrop-blur dark:bg-slate-900/40">
+        <tr class="text-left text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+          <th class="px-5 py-3">Proyecto</th>
+          <th class="px-5 py-3">Estudiante</th>
+          <th class="px-5 py-3">Estado</th>
+          <th class="px-5 py-3">Entrega</th>
+          <th class="px-5 py-3 text-right">Acciones</th>
         </tr>
       </thead>
-      <tbody class="divide-y divide-slate-100 dark:divide-slate-800">
+      <tbody class="divide-y divide-slate-100/60 dark:divide-slate-800/60">
         <?php if ($projects === []): ?>
           <tr>
-            <td colspan="5" class="px-4 py-6 text-center text-sm text-slate-500">Aún no se registran proyectos.</td>
+            <td colspan="5" class="px-5 py-7 text-center text-sm text-slate-500">Aún no se registran proyectos.</td>
           </tr>
         <?php else: ?>
           <?php foreach ($projects as $project): ?>
             <?php $isProjectDirector = !empty($isDirector) && (int) ($project['director_id'] ?? 0) === $userId; ?>
-            <tr class="hover:bg-slate-50/80 dark:hover:bg-slate-800/40">
-              <td class="px-4 py-3">
+            <tr class="transition-colors duration-200 hover:bg-indigo-500/5 dark:hover:bg-indigo-500/10">
+              <td class="px-5 py-4">
                 <div class="font-medium text-slate-800 dark:text-slate-100"><?= e($project['title']); ?></div>
                 <div class="text-xs text-slate-500">Director: <?= e($project['director_name']); ?></div>
               </td>
-              <td class="px-4 py-3">
+              <td class="px-5 py-4">
                 <div class="text-sm font-medium text-slate-700 dark:text-slate-200"><?= e($project['student_name']); ?></div>
                 <div class="text-[11px] text-slate-400"><?= e($project['student_email']); ?></div>
               </td>
-              <td class="px-4 py-3">
-                <span class="inline-flex items-center rounded-lg px-2 py-1 text-xs font-semibold <?= e(status_badge_classes($project['status'])); ?>">
+              <td class="px-5 py-4">
+                <span class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold <?= e(status_badge_classes($project['status'])); ?>">
                   <?= e(humanize_status($project['status'])); ?>
                 </span>
               </td>
-              <td class="px-4 py-3 text-sm">
+              <td class="px-5 py-4 text-sm">
                 <?= e(format_dashboard_date($project['due_date'] ?? null)); ?>
               </td>
-              <td class="px-4 py-3 text-right">
+              <td class="px-5 py-4 text-right">
                 <div class="flex justify-end gap-2">
-                  <a class="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-1 text-xs text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800" href="<?= e(url('/dashboard?tab=proyectos&project=' . (int) $project['id'])); ?>">
-                    <i data-lucide="eye" class="h-3.5 w-3.5"></i> Ver
+                  <a class="inline-flex items-center gap-1 rounded-full border border-slate-200/80 px-3 py-1 text-xs font-medium text-slate-600 transition duration-200 hover:-translate-y-0.5 hover:bg-white dark:border-slate-700/60 dark:text-slate-300 dark:hover:bg-slate-900" href="<?= e(url('/dashboard?tab=proyectos&project=' . (int) $project['id'])); ?>">
+                    <i data-lucide="eye" class="h-3.5 w-3.5"></i>
+                    Ver
                   </a>
                   <?php if ($isProjectDirector): ?>
                     <form method="post" action="<?= e(url('/projects/status')); ?>" class="inline-flex items-center gap-1">
                       <input type="hidden" name="project_id" value="<?= e((string) $project['id']); ?>" />
                       <label class="sr-only" for="project-status-<?= e((string) $project['id']); ?>">Estado</label>
-                      <select id="project-status-<?= e((string) $project['id']); ?>" name="status" class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs outline-none dark:border-slate-700 dark:bg-slate-900">
+                      <select id="project-status-<?= e((string) $project['id']); ?>" name="status" class="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs outline-none transition focus:border-indigo-500 dark:border-slate-700/60 dark:bg-slate-900">
                         <?php foreach (['planificado','en_progreso','en_riesgo','completado'] as $statusOption): ?>
                           <option value="<?= e($statusOption); ?>" <?= $statusOption === $project['status'] ? 'selected' : ''; ?>><?= e(humanize_status($statusOption)); ?></option>
                         <?php endforeach; ?>
                       </select>
-                      <button type="submit" class="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-700">
+                      <button type="submit" class="inline-flex items-center gap-1 rounded-full bg-indigo-600 px-3 py-1 text-xs font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-indigo-700">
                         <i data-lucide="save" class="h-3.5 w-3.5"></i>
                       </button>
                     </form>

--- a/app/Views/dashboard/components/shared/alerts.php
+++ b/app/Views/dashboard/components/shared/alerts.php
@@ -1,5 +1,5 @@
 <?php if ($success): ?>
-  <div class="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-100">
+  <div class="mb-4 rounded-2xl border border-emerald-400/40 bg-emerald-50/80 px-4 py-3 text-sm text-emerald-700 shadow-lg backdrop-blur-sm dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-100">
     <?= e($success); ?>
   </div>
 <?php endif; ?>
@@ -7,7 +7,7 @@
 <?php if ($errors): ?>
   <div class="mb-4 space-y-2">
     <?php foreach ($errors as $error): ?>
-      <div class="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-800 dark:bg-rose-900/40 dark:text-rose-100">
+      <div class="rounded-2xl border border-rose-400/40 bg-rose-50/80 px-4 py-3 text-sm text-rose-700 shadow-lg backdrop-blur-sm dark:border-rose-900/60 dark:bg-rose-950/40 dark:text-rose-100">
         <?= e($error); ?>
       </div>
     <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- refresh the dashboard head layout with gradient hero banner and quick metric chips
- restyle each dashboard module using glassmorphism cards, soft gradients, and animated hover feedback
- introduce global background gradients and utility classes for a cohesive visual theme

## Testing
- php -l app/Views/dashboard/components/layout/head.php
- php -l app/Views/dashboard/components/layout/main.php
- php -l app/Views/dashboard/components/layout/page-heading.php
- php -l app/Views/dashboard/components/sections/comments.php
- php -l app/Views/dashboard/components/sections/dashboard-overview.php
- php -l app/Views/dashboard/components/sections/milestones.php
- php -l app/Views/dashboard/components/sections/progress.php
- php -l app/Views/dashboard/components/sections/projects.php
- php -l app/Views/dashboard/components/shared/alerts.php

------
https://chatgpt.com/codex/tasks/task_e_68dcc184628c832e87841923518767ef