### PR TITLE
Refina diseño minimalista en acceso y tablero

### DIFF
--- a/app/Views/auth/index.php
+++ b/app/Views/auth/index.php
@@ -37,16 +37,25 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
 
     html {
       font-family: Inter, system-ui, ui-sans-serif;
+      background-color: #f8fafc;
     }
 
-    .scrollbar-invisible {
-      scrollbar-width: none;
-      -ms-overflow-style: none;
+    body {
+      background-color: #f8fafc;
     }
 
-    .scrollbar-invisible::-webkit-scrollbar {
-      width: 0;
-      height: 0;
+    .surface-card {
+      border-radius: 24px;
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      background: rgba(255, 255, 255, 0.95);
+      box-shadow: 0 24px 60px -36px rgba(15, 23, 42, 0.45);
+      backdrop-filter: blur(12px);
+    }
+
+    .tab-active {
+      background-color: rgba(255, 255, 255, 0.95);
+      box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.35);
+      color: #0f172a !important;
     }
 
     .fade-enter {
@@ -60,7 +69,6 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
       transition: opacity 0.18s ease, transform 0.18s ease;
     }
 
-    /* Ajuste para pantallas muy pequenas */
     @media (max-width: 375px) {
       .text-4xl-mobile {
         font-size: 2.25rem;
@@ -68,7 +76,6 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
       }
     }
 
-    /* Ajuste para tablets en modo vertical */
     @media (min-width: 768px) and (max-width: 1023px) and (orientation: portrait) {
       .tablet-portrait-stack {
         flex-direction: column;
@@ -76,266 +83,287 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
     }
   </style>
 </head>
-<body class="min-h-full bg-slate-50">
-  <div class="min-h-screen lg:flex tablet-portrait-stack">
-    <aside class="lg:w-1/2 lg:h-screen relative flex items-center justify-center px-4 sm:px-8 md:px-12 lg:px-16 xl:px-20 py-8 sm:py-12 lg:py-16 bg-[#1869db] text-white lg:flex-shrink-0">
-      <div class="max-w-lg w-full">
-        <div class="mb-8 sm:mb-12 lg:mb-16 flex flex-wrap items-center justify-center lg:justify-start gap-4 sm:gap-6 lg:gap-10 opacity-95">
-          <div class="h-16 sm:h-18 lg:h-20 flex items-center">
-            <img src="<?= e(url('/assets/logo.svg')); ?>" alt="Logo" class="h-full w-auto object-contain text-white" />
+<body class="min-h-full">
+  <div class="flex min-h-screen items-center justify-center px-4 py-10 sm:px-6 lg:px-10">
+    <div class="grid w-full max-w-6xl items-center gap-10 lg:grid-cols-[1.05fr_1fr]">
+      <aside class="surface-card relative isolate overflow-hidden px-6 py-10 text-slate-900 sm:px-8 lg:px-12">
+        <div class="absolute inset-0 -z-10 bg-gradient-to-br from-indigo-500/15 via-sky-500/10 to-transparent"></div>
+        <div class="flex flex-col gap-10">
+          <div class="flex items-center gap-3">
+            <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-600/90 text-lg font-semibold text-white">GT</span>
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Gestor de Titulación</p>
+              <p class="mt-1 text-sm font-medium text-slate-600">Tecnológico de Mérida</p>
+            </div>
           </div>
+
+          <div class="space-y-6">
+            <p class="text-3xl font-semibold leading-[1.05] text-slate-900 sm:text-4xl text-4xl-mobile">
+              Un acceso claro para dar seguimiento a tus proyectos.
+            </p>
+            <p class="max-w-md text-sm leading-relaxed text-slate-600">
+              Organiza entregables, colabora con tu director y avanza paso a paso con una experiencia ligera y ordenada.
+            </p>
+          </div>
+
+          <ul class="space-y-3 text-sm text-slate-600">
+            <li class="flex items-center gap-3">
+              <span class="inline-flex h-2.5 w-2.5 flex-none rounded-full bg-indigo-500"></span>
+              Seguimiento en tiempo real de hitos y avances.
+            </li>
+            <li class="flex items-center gap-3">
+              <span class="inline-flex h-2.5 w-2.5 flex-none rounded-full bg-indigo-500"></span>
+              Comunicación directa entre estudiantes y directores.
+            </li>
+            <li class="flex items-center gap-3">
+              <span class="inline-flex h-2.5 w-2.5 flex-none rounded-full bg-indigo-500"></span>
+              Documentación centralizada para cada proyecto.
+            </li>
+          </ul>
         </div>
+      </aside>
 
-        <div class="text-center lg:text-left">
-          <p class="text-3xl sm:text-4xl lg:text-5xl text-4xl-mobile font-extrabold leading-tight">
-            Hola,<br /><span class="font-extrabold">bienvenido</span>
-          </p>
-          <p class="mt-4 sm:mt-6 max-w-md mx-auto lg:mx-0 text-white/80 text-base sm:text-lg">
-            Inicia sesion o crea una cuenta para ingresar al sistema.
-          </p>
-        </div>
-      </div>
+      <main class="surface-card px-5 py-8 sm:px-7 sm:py-9 lg:px-8">
+        <div class="space-y-6">
+          <?php if ($user): ?>
+            <div class="rounded-2xl border border-slate-200/70 bg-white/90 px-5 py-4 text-sm text-slate-600">
+              <p class="font-medium text-slate-500">Sesión activa</p>
+              <div class="mt-2 text-lg font-semibold text-slate-800"><?= e($user['full_name']); ?></div>
+              <div class="text-sm text-slate-500"><?= e(strtolower($user['email'])); ?> &bull; <?= e(ucfirst($user['role'])); ?></div>
+              <form class="mt-4" method="post" action="<?= e(url('/logout')); ?>">
+                <button type="submit" class="inline-flex items-center gap-2 rounded-xl border border-slate-200/80 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-indigo-200 hover:text-indigo-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200">
+                  Cerrar sesión
+                </button>
+              </form>
+            </div>
+          <?php endif; ?>
 
-      <div class="hidden lg:block absolute right-0 top-0 h-full w-px bg-white/20"></div>
-    </aside>
+          <?php if ($success): ?>
+            <div class="rounded-2xl border border-emerald-200/70 bg-emerald-50/80 px-5 py-4 text-sm text-emerald-700">
+              <?= e($success); ?>
+            </div>
+          <?php endif; ?>
 
-    <main class="lg:w-1/2 lg:h-screen lg:overflow-y-auto flex items-center justify-center px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 py-6 sm:py-8 lg:py-16">
-      <div class="w-full max-w-md">
-        <?php if ($user): ?>
-          <div class="mb-5 rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
-            <p class="text-sm text-slate-500">Sesion activa</p>
-            <div class="mt-1 text-lg font-semibold text-slate-800"><?= e($user['full_name']); ?></div>
-            <div class="text-sm text-slate-500"><?= e(strtolower($user['email'])); ?> &bull; <?= e(ucfirst($user['role'])); ?></div>
-            <form class="mt-4" method="post" action="<?= e(url('/logout')); ?>">
-              <button type="submit" class="inline-flex items-center rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-200">
-                Cerrar sesion
+          <div>
+            <div id="auth-tabs" role="tablist" aria-label="Cambiar vista" data-active-tab="<?= e($activeTab); ?>" class="grid grid-cols-2 gap-1 rounded-full bg-slate-100/80 p-1.5 text-sm font-medium text-slate-500">
+              <button id="tab-login" type="button" role="tab" aria-selected="<?= $activeTab === 'login' ? 'true' : 'false'; ?>" aria-controls="panel-login" class="tab inline-flex items-center justify-center rounded-full px-4 py-2.5 text-sm font-medium transition-colors duration-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200 <?= $activeTab === 'login' ? 'tab-active' : ''; ?>">
+                Iniciar sesión
               </button>
-            </form>
+              <button id="tab-register" type="button" role="tab" aria-selected="<?= $activeTab === 'register' ? 'true' : 'false'; ?>" aria-controls="panel-register" class="tab inline-flex items-center justify-center rounded-full px-4 py-2.5 text-sm font-medium transition-colors duration-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200 <?= $activeTab === 'register' ? 'tab-active' : ''; ?>">
+                Crear cuenta
+              </button>
+            </div>
           </div>
-        <?php endif; ?>
 
-        <?php if ($success): ?>
-          <div class="mb-5 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm text-emerald-700">
-            <?= e($success); ?>
-          </div>
-        <?php endif; ?>
+          <div id="panel-container" class="relative mt-6 transition-[height] duration-300 ease-out">
+            <section id="panel-login" class="panel <?= $activeTab === 'register' ? 'hidden' : ''; ?>" role="tabpanel" aria-hidden="<?= $activeTab === 'register' ? 'true' : 'false'; ?>">
+              <div class="rounded-2xl border border-slate-200/70 bg-white/95 p-5 shadow-sm">
+                <form class="space-y-5" method="post" action="<?= e(url('/login')); ?>">
+                  <?php if ($hasError('login_general')): ?>
+                    <div class="rounded-xl border border-rose-200/80 bg-rose-50/80 px-4 py-3 text-sm text-rose-600">
+                      <?= e($errorText('login_general')); ?>
+                    </div>
+                  <?php endif; ?>
 
-        <div class="mb-6 lg:mb-8">
-          <div id="auth-tabs" role="tablist" aria-label="Cambiar vista" data-active-tab="<?= e($activeTab); ?>" class="w-full rounded-2xl bg-slate-200 p-1 grid grid-cols-2">
-            <button id="tab-login" type="button" role="tab" aria-selected="<?= $activeTab === 'login' ? 'true' : 'false'; ?>" aria-controls="panel-login" class="tab rounded-xl px-4 sm:px-6 lg:px-8 py-3 text-sm font-medium text-slate-700 transition <?= $activeTab === 'login' ? 'bg-white shadow-sm' : ''; ?>">
-              Iniciar sesion
-            </button>
-            <button id="tab-register" type="button" role="tab" aria-selected="<?= $activeTab === 'register' ? 'true' : 'false'; ?>" aria-controls="panel-register" class="tab rounded-xl px-4 sm:px-6 lg:px-8 py-3 text-sm font-medium text-slate-700 transition <?= $activeTab === 'register' ? 'bg-white shadow-sm' : ''; ?>">
-              Crear cuenta
-            </button>
+                  <div class="space-y-2">
+                    <label for="login-email" class="text-sm font-semibold text-slate-700">Correo institucional</label>
+                    <input id="login-email" type="email" name="email" required value="<?= $oldValue('login_email'); ?>" class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 <?= $hasError('login_email') ? 'border-rose-400 focus:border-rose-500 focus:ring-rose-300' : ''; ?>" placeholder="correo@itmerida.edu.mx" autocomplete="email" />
+                    <?php if ($hasError('login_email')): ?>
+                      <p class="text-xs font-medium text-rose-600"><?= e($errorText('login_email')); ?></p>
+                    <?php endif; ?>
+                  </div>
+
+                  <div class="space-y-2">
+                    <div class="flex items-center justify-between">
+                      <label for="password" class="text-sm font-semibold text-slate-700">Contraseña</label>
+                    </div>
+                    <div class="relative">
+                      <input id="password" type="password" name="password" required class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 pr-12 text-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 <?= $hasError('login_password') ? 'border-rose-400 focus:border-rose-500 focus:ring-rose-300' : ''; ?>" placeholder="Tu contraseña" autocomplete="current-password" />
+                      <button type="button" id="togglePassBtn" class="absolute inset-y-0 right-0 flex items-center pr-4 text-slate-400 transition hover:text-slate-600" aria-label="Mostrar contraseña">
+                        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                          <circle cx="12" cy="12" r="3"></circle>
+                        </svg>
+                      </button>
+                    </div>
+                    <?php if ($hasError('login_password')): ?>
+                      <p class="text-xs font-medium text-rose-600"><?= e($errorText('login_password')); ?></p>
+                    <?php endif; ?>
+                  </div>
+
+                  <div class="flex justify-end">
+                    <a href="<?= e(url('/password/change')); ?>" class="text-sm font-semibold text-indigo-600 transition hover:text-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200">
+                      ¿Olvidaste tu contraseña?
+                    </a>
+                  </div>
+
+                  <button type="submit" class="w-full rounded-xl bg-indigo-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200">
+                    Ingresar
+                  </button>
+                </form>
+              </div>
+            </section>
+
+            <section id="panel-register" class="panel <?= $activeTab === 'register' ? '' : 'hidden'; ?>" role="tabpanel" aria-hidden="<?= $activeTab === 'register' ? 'false' : 'true'; ?>">
+              <div class="rounded-2xl border border-slate-200/70 bg-white/95 p-5 shadow-sm">
+                <form class="space-y-5" method="post" action="<?= e(url('/register')); ?>">
+                  <?php if ($hasError('register_general')): ?>
+                    <div class="rounded-xl border border-rose-200/80 bg-rose-50/80 px-4 py-3 text-sm text-rose-600">
+                      <?= e($errorText('register_general')); ?>
+                    </div>
+                  <?php endif; ?>
+
+                  <div class="space-y-2">
+                    <label for="full_name" class="text-sm font-semibold text-slate-700">Nombre completo</label>
+                    <input id="full_name" type="text" name="full_name" required value="<?= $oldValue('full_name'); ?>" class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 <?= $hasError('full_name') ? 'border-rose-400 focus:border-rose-500 focus:ring-rose-300' : ''; ?>" placeholder="Nombre y apellidos" autocomplete="name" />
+                    <?php if ($hasError('full_name')): ?>
+                      <p class="text-xs font-medium text-rose-600"><?= e($errorText('full_name')); ?></p>
+                    <?php endif; ?>
+                  </div>
+
+                  <div class="space-y-2">
+                    <label for="register-email" class="text-sm font-semibold text-slate-700">Correo institucional</label>
+                    <input id="register-email" type="email" name="email" required value="<?= $oldValue('email'); ?>" class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 <?= $hasError('email') ? 'border-rose-400 focus:border-rose-500 focus:ring-rose-300' : ''; ?>" placeholder="correo@itmerida.edu.mx" autocomplete="email" />
+                    <?php if ($hasError('email')): ?>
+                      <p class="text-xs font-medium text-rose-600"><?= e($errorText('email')); ?></p>
+                    <?php endif; ?>
+                  </div>
+
+                  <div class="space-y-2">
+                    <label for="role" class="text-sm font-semibold text-slate-700">Rol en el sistema</label>
+                    <select id="role" name="role" class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500">
+                      <option value="estudiante" <?= $roleValue === 'estudiante' ? 'selected' : ''; ?>>Estudiante</option>
+                      <option value="director" <?= $roleValue === 'director' ? 'selected' : ''; ?>>Director</option>
+                    </select>
+                  </div>
+
+                  <div id="field-matricula" class="space-y-2 <?= $roleValue === 'director' ? 'hidden' : ''; ?>">
+                    <label for="matricula" class="text-sm font-semibold text-slate-700">Matricula</label>
+                    <input id="matricula" type="text" name="matricula" value="<?= $oldValue('matricula'); ?>" class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 <?= $hasError('matricula') ? 'border-rose-400 focus:border-rose-500 focus:ring-rose-300' : ''; ?>" placeholder="Ej. B12345" />
+                    <?php if ($hasError('matricula')): ?>
+                      <p class="text-xs font-medium text-rose-600"><?= e($errorText('matricula')); ?></p>
+                    <?php endif; ?>
+                  </div>
+
+                  <div id="field-depto" class="space-y-2 <?= $roleValue === 'director' ? '' : 'hidden'; ?>">
+                    <label for="department" class="text-sm font-semibold text-slate-700">Departamento</label>
+                    <input id="department" type="text" name="department" value="<?= $oldValue('department'); ?>" class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 <?= $hasError('department') ? 'border-rose-400 focus:border-rose-500 focus:ring-rose-300' : ''; ?>" placeholder="Ej. Ciencias Básicas" />
+                    <?php if ($hasError('department')): ?>
+                      <p class="text-xs font-medium text-rose-600"><?= e($errorText('department')); ?></p>
+                    <?php endif; ?>
+                  </div>
+
+                  <div class="space-y-2">
+                    <label for="register-password" class="text-sm font-semibold text-slate-700">Contraseña</label>
+                    <div class="relative">
+                      <input id="register-password" type="password" name="password" required class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 pr-12 text-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 <?= $hasError('password') ? 'border-rose-400 focus:border-rose-500 focus:ring-rose-300' : ''; ?>" placeholder="Mínimo 8 caracteres" autocomplete="new-password" />
+                      <button type="button" class="toggle-eye absolute inset-y-0 right-0 flex items-center pr-4 text-slate-400 transition hover:text-slate-600" data-toggle-for="register-password" aria-label="Mostrar contraseña">
+                        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                          <circle cx="12" cy="12" r="3"></circle>
+                        </svg>
+                      </button>
+                    </div>
+                    <?php if ($hasError('password')): ?>
+                      <p class="text-xs font-medium text-rose-600"><?= e($errorText('password')); ?></p>
+                    <?php endif; ?>
+                  </div>
+
+                  <div class="space-y-2">
+                    <label for="password_confirmation" class="text-sm font-semibold text-slate-700">Confirmar contraseña</label>
+                    <div class="relative">
+                      <input id="password_confirmation" type="password" name="password_confirmation" required class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 pr-12 text-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 <?= $hasError('password_confirmation') ? 'border-rose-400 focus:border-rose-500 focus:ring-rose-300' : ''; ?>" placeholder="Repite la contraseña" autocomplete="new-password" />
+                      <button type="button" class="toggle-eye absolute inset-y-0 right-0 flex items-center pr-4 text-slate-400 transition hover:text-slate-600" data-toggle-for="password_confirmation" aria-label="Mostrar contraseña">
+                        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                          <circle cx="12" cy="12" r="3"></circle>
+                        </svg>
+                      </button>
+                    </div>
+                    <?php if ($hasError('password_confirmation')): ?>
+                      <p class="text-xs font-medium text-rose-600"><?= e($errorText('password_confirmation')); ?></p>
+                    <?php endif; ?>
+                  </div>
+
+                  <button type="submit" class="w-full rounded-xl bg-indigo-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200">
+                    Crear cuenta
+                  </button>
+                </form>
+              </div>
+            </section>
           </div>
         </div>
-
-        <div id="panel-container" class="relative overflow-y-auto scrollbar-invisible transition-[height] duration-300 ease-out max-h-[calc(100vh-200px)] sm:max-h-[calc(100vh-180px)] lg:max-h-[70vh]">
-          <section id="panel-login" class="panel <?= $activeTab === 'register' ? 'hidden' : ''; ?>" role="tabpanel" aria-hidden="<?= $activeTab === 'register' ? 'true' : 'false'; ?>">
-            <div class="rounded-2xl bg-white p-4 sm:p-6 lg:p-8 shadow-sm ring-1 ring-slate-200">
-              <form class="space-y-4 sm:space-y-5" method="post" action="<?= e(url('/login')); ?>">
-                <?php if ($hasError('login_general')): ?>
-                  <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
-                    <?= e($errorText('login_general')); ?>
-                  </div>
-                <?php endif; ?>
-
-                <div>
-                  <label for="login-email" class="mb-2 block text-sm font-semibold text-slate-700">Correo institucional</label>
-                  <input id="login-email" type="email" name="email" required value="<?= $oldValue('login_email'); ?>" class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('login_email') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="correo@itmerida.edu.mx" autocomplete="email" />
-                  <?php if ($hasError('login_email')): ?>
-                    <p class="mt-2 text-xs font-medium text-red-600"><?= e($errorText('login_email')); ?></p>
-                  <?php endif; ?>
-                </div>
-
-                <div>
-                  <div class="mb-2 flex items-center justify-between">
-                    <label for="password" class="block text-sm font-semibold text-slate-700">Contraseña</label>
-                  </div>
-                  <div class="relative">
-                    <input id="password" type="password" name="password" required class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 pr-12 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('login_password') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="Tu contraseña" autocomplete="current-password" />
-                    <button type="button" id="togglePassBtn" class="absolute inset-y-0 right-0 flex items-center pr-4 text-slate-400 hover:text-slate-600" aria-label="Mostrar contraseña">
-                      <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-                        <circle cx="12" cy="12" r="3"></circle>
-                      </svg>
-                    </button>
-                  </div>
-                  <?php if ($hasError('login_password')): ?>
-                    <p class="mt-2 text-xs font-medium text-red-600"><?= e($errorText('login_password')); ?></p>
-                  <?php endif; ?>
-                </div>
-
-                <div class="flex justify-end">
-                  <a href="<?= e(url('/password/change')); ?>" class="text-sm font-semibold text-[#1869db] hover:text-[#155cc1] focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#1869db]">
-                    ¿Olvidaste tu contraseña?
-                  </a>
-                </div>
-
-                <button type="submit" class="w-full rounded-xl bg-[#1869db] px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-[#155cc1] focus:outline-none focus:ring-2 focus:ring-indigo-200">
-                  Ingresar
-                </button>
-              </form>
-            </div>
-          </section>
-
-          <section id="panel-register" class="panel <?= $activeTab === 'register' ? '' : 'hidden'; ?>" role="tabpanel" aria-hidden="<?= $activeTab === 'register' ? 'false' : 'true'; ?>">
-            <div class="rounded-2xl bg-white p-4 sm:p-6 lg:p-8 shadow-sm ring-1 ring-slate-200">
-              <form class="space-y-4 sm:space-y-5" method="post" action="<?= e(url('/register')); ?>">
-                <?php if ($hasError('register_general')): ?>
-                  <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
-                    <?= e($errorText('register_general')); ?>
-                  </div>
-                <?php endif; ?>
-
-                <div>
-                  <label for="full_name" class="mb-2 block text-sm font-semibold text-slate-700">Nombre completo</label>
-                  <input id="full_name" type="text" name="full_name" required value="<?= $oldValue('full_name'); ?>" class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('full_name') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="Nombre y apellidos" autocomplete="name" />
-                  <?php if ($hasError('full_name')): ?>
-                    <p class="mt-2 text-xs font-medium text-red-600"><?= e($errorText('full_name')); ?></p>
-                  <?php endif; ?>
-                </div>
-
-                <div>
-                  <label for="register-email" class="mb-2 block text-sm font-semibold text-slate-700">Correo institucional</label>
-                  <input id="register-email" type="email" name="email" required value="<?= $oldValue('email'); ?>" class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('email') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="correo@itmerida.edu.mx" autocomplete="email" />
-                  <?php if ($hasError('email')): ?>
-                    <p class="mt-2 text-xs font-medium text-red-600"><?= e($errorText('email')); ?></p>
-                  <?php endif; ?>
-                </div>
-
-                <div>
-                  <label for="role" class="mb-2 block text-sm font-semibold text-slate-700">Rol en el sistema</label>
-                  <select id="role" name="role" class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:border-indigo-500 focus:ring-indigo-200">
-                    <option value="estudiante" <?= $roleValue === 'estudiante' ? 'selected' : ''; ?>>Estudiante</option>
-                    <option value="director" <?= $roleValue === 'director' ? 'selected' : ''; ?>>Director</option>
-                  </select>
-                </div>
-
-                <div id="field-matricula" class="space-y-2 <?= $roleValue === 'director' ? 'hidden' : ''; ?>">
-                  <label for="matricula" class="block text-sm font-semibold text-slate-700">Matricula</label>
-                  <input id="matricula" type="text" name="matricula" value="<?= $oldValue('matricula'); ?>" class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('matricula') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="Ej. B12345" />
-                  <?php if ($hasError('matricula')): ?>
-                    <p class="mt-1 text-xs font-medium text-red-600"><?= e($errorText('matricula')); ?></p>
-                  <?php endif; ?>
-                </div>
-
-                <div id="field-depto" class="space-y-2 <?= $roleValue === 'director' ? '' : 'hidden'; ?>">
-                  <label for="department" class="block text-sm font-semibold text-slate-700">Departamento</label>
-                  <input id="department" type="text" name="department" value="<?= $oldValue('department'); ?>" class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('department') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="Ej. Ciencias Basicas" />
-                  <?php if ($hasError('department')): ?>
-                    <p class="mt-1 text-xs font-medium text-red-600"><?= e($errorText('department')); ?></p>
-                  <?php endif; ?>
-                </div>
-
-                <div>
-                  <label for="register-password" class="mb-2 block text-sm font-semibold text-slate-700">Contraseña</label>
-                  <div class="relative">
-                    <input id="register-password" type="password" name="password" required class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 pr-12 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('password') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="Minimo 8 caracteres" autocomplete="new-password" />
-                    <button type="button" class="toggle-eye absolute inset-y-0 right-0 flex items-center pr-4 text-slate-400 hover:text-slate-600" data-toggle-for="register-password" aria-label="Mostrar contraseña">
-                      <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-                        <circle cx="12" cy="12" r="3"></circle>
-                      </svg>
-                    </button>
-                  </div>
-                  <?php if ($hasError('password')): ?>
-                    <p class="mt-2 text-xs font-medium text-red-600"><?= e($errorText('password')); ?></p>
-                  <?php endif; ?>
-                </div>
-
-                <div>
-                  <label for="password_confirmation" class="mb-2 block text-sm font-semibold text-slate-700">Confirmar contraseña</label>
-                  <div class="relative">
-                    <input id="password_confirmation" type="password" name="password_confirmation" required class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 pr-12 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('password_confirmation') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="Repite la contraseña" autocomplete="new-password" />
-                    <button type="button" class="toggle-eye absolute inset-y-0 right-0 flex items-center pr-4 text-slate-400 hover:text-slate-600" data-toggle-for="password_confirmation" aria-label="Mostrar contraseña">
-                      <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-                        <circle cx="12" cy="12" r="3"></circle>
-                      </svg>
-                    </button>
-                  </div>
-                  <?php if ($hasError('password_confirmation')): ?>
-                    <p class="mt-2 text-xs font-medium text-red-600"><?= e($errorText('password_confirmation')); ?></p>
-                  <?php endif; ?>
-                </div>
-
-                <button type="submit" class="w-full rounded-xl bg-[#1869db] px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-[#155cc1] focus:outline-none focus:ring-2 focus:ring-indigo-200">
-                  Crear cuenta
-                </button>
-              </form>
-            </div>
-          </section>
-        </div>
-      </div>
-    </main>
+      </main>
+    </div>
   </div>
 
   <script>
-    const tabButtons = Array.from(document.querySelectorAll('#auth-tabs .tab'));
-    const panels = Array.from(document.querySelectorAll('.panel'));
     const authTabs = document.getElementById('auth-tabs');
+    const panelContainer = document.getElementById('panel-container');
 
     function setContainerHeightFor(panel) {
-      const container = document.getElementById('panel-container');
-      if (!panel || !container) return;
+      if (!panel || !panelContainer) return;
       const clone = panel.cloneNode(true);
       clone.style.height = 'auto';
       clone.classList.remove('hidden');
       clone.style.position = 'absolute';
       clone.style.visibility = 'hidden';
-      container.appendChild(clone);
+      panelContainer.appendChild(clone);
       const height = clone.getBoundingClientRect().height;
-      container.style.height = height + 'px';
-      container.removeChild(clone);
+      panelContainer.style.height = height + 'px';
+      panelContainer.removeChild(clone);
     }
 
-    function activateTab(button) {
-      const targetId = button.getAttribute('aria-controls');
-      const nextPanel = document.getElementById(targetId);
-      if (!nextPanel) return;
+    if (authTabs && panelContainer) {
+      const tabButtons = Array.from(authTabs.querySelectorAll('[role="tab"]'));
+      const panels = Array.from(panelContainer.querySelectorAll('[role="tabpanel"]'));
 
-      tabButtons.forEach((btn) => {
-        btn.classList.remove('bg-white', 'shadow-sm');
-        btn.setAttribute('aria-selected', 'false');
-      });
+      function activateTab(button) {
+        const targetId = button.getAttribute('aria-controls');
+        const nextPanel = document.getElementById(targetId);
+        if (!nextPanel) return;
 
-      panels.forEach((panel) => {
-        panel.classList.add('hidden');
-        panel.setAttribute('aria-hidden', 'true');
-      });
+        tabButtons.forEach((btn) => {
+          btn.classList.remove('tab-active');
+          btn.setAttribute('aria-selected', 'false');
+        });
 
-      button.classList.add('bg-white', 'shadow-sm');
-      button.setAttribute('aria-selected', 'true');
+        panels.forEach((panel) => {
+          panel.classList.add('hidden');
+          panel.setAttribute('aria-hidden', 'true');
+        });
 
-      nextPanel.classList.remove('hidden');
-      nextPanel.setAttribute('aria-hidden', 'false');
-      nextPanel.classList.add('fade-enter');
-      requestAnimationFrame(() => nextPanel.classList.add('fade-enter-active'));
-      setTimeout(() => nextPanel.classList.remove('fade-enter', 'fade-enter-active'), 200);
-      setContainerHeightFor(nextPanel);
-    }
+        button.classList.add('tab-active');
+        button.setAttribute('aria-selected', 'true');
 
-    window.addEventListener('load', () => {
-      const requestedTab = authTabs.dataset.activeTab || 'login';
-      const defaultButton = requestedTab === 'register' ? document.getElementById('tab-register') : document.getElementById('tab-login');
-      if (defaultButton) {
-        activateTab(defaultButton);
+        nextPanel.classList.remove('hidden');
+        nextPanel.setAttribute('aria-hidden', 'false');
+        nextPanel.classList.add('fade-enter');
+        requestAnimationFrame(() => nextPanel.classList.add('fade-enter-active'));
+        setTimeout(() => nextPanel.classList.remove('fade-enter', 'fade-enter-active'), 200);
+        setContainerHeightFor(nextPanel);
       }
-    });
 
-    tabButtons.forEach((btn) => btn.addEventListener('click', () => activateTab(btn)));
+      window.addEventListener('load', () => {
+        const requestedTab = authTabs.dataset.activeTab || 'login';
+        const defaultButton = requestedTab === 'register' ? document.getElementById('tab-register') : document.getElementById('tab-login');
+        if (defaultButton) {
+          activateTab(defaultButton);
+        }
+      });
 
-    authTabs.addEventListener('keydown', (event) => {
-      if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
-      event.preventDefault();
-      const index = tabButtons.indexOf(document.activeElement);
-      if (index === -1) return;
-      const nextIndex = event.key === 'ArrowRight' ? (index + 1) % tabButtons.length : (index - 1 + tabButtons.length) % tabButtons.length;
-      tabButtons[nextIndex].focus();
-      activateTab(tabButtons[nextIndex]);
-    });
+      tabButtons.forEach((btn) => btn.addEventListener('click', () => activateTab(btn)));
+
+      authTabs.addEventListener('keydown', (event) => {
+        if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+        event.preventDefault();
+        const index = tabButtons.indexOf(document.activeElement);
+        if (index === -1) return;
+        const nextIndex = event.key === 'ArrowRight' ? (index + 1) % tabButtons.length : (index - 1 + tabButtons.length) % tabButtons.length;
+        tabButtons[nextIndex].focus();
+        activateTab(tabButtons[nextIndex]);
+      });
+    }
 
     function eyeSvg(open = true) {
       return open
@@ -422,12 +450,9 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
 
     input:focus,
     select:focus,
-    button:focus:not(.tab) {\r\n      box-shadow: 0 0 0 2px rgba(30, 58, 138, 0.2);\r\n    }
+    button:focus:not(.tab) {
+      box-shadow: 0 0 0 2px rgba(30, 58, 138, 0.15);
+    }
   </style>
 </body>
 </html>
-
-
-
-
-

--- a/app/Views/auth/password_change.php
+++ b/app/Views/auth/password_change.php
@@ -18,80 +18,94 @@ $old = $old ?? [];
       font-family: Inter, system-ui, ui-sans-serif;
       background-color: #f8fafc;
     }
+
+    body {
+      background-color: #f8fafc;
+    }
+
+    .surface-card {
+      border-radius: 24px;
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      background: rgba(255, 255, 255, 0.95);
+      box-shadow: 0 24px 60px -36px rgba(15, 23, 42, 0.4);
+      backdrop-filter: blur(12px);
+    }
   </style>
 </head>
-<body class="min-h-screen bg-slate-50">
+<body class="min-h-screen">
   <div class="flex min-h-screen items-center justify-center px-4 py-12">
-    <div class="w-full max-w-md">
-      <div class="mb-6 text-center">
-        <h1 class="text-2xl font-bold text-slate-800">Recuperar contrase&ntilde;a</h1>
+    <div class="w-full max-w-lg space-y-8">
+      <div class="text-center">
+        <h1 class="text-3xl font-semibold text-slate-900">Recuperar contrase&ntilde;a</h1>
         <p class="mt-2 text-sm text-slate-600">Ingresa tu correo institucional y establece una nueva contrase&ntilde;a para tu cuenta.</p>
       </div>
 
       <?php if ($status): ?>
-        <div class="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+        <div class="rounded-2xl border border-emerald-200/70 bg-emerald-50/80 px-5 py-4 text-sm text-emerald-700">
           <?= e($status); ?>
         </div>
       <?php endif; ?>
 
-      <form method="post" action="<?= e(url('/password/change')); ?>" class="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
-        <div>
-          <label for="email" class="mb-2 block text-sm font-semibold text-slate-700">Correo institucional</label>
-          <input
-            id="email"
-            type="email"
-            name="email"
-            value="<?= e($old['email'] ?? ''); ?>"
-            required
-            class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:border-indigo-500 focus:ring-indigo-200"
-            placeholder="correo@itmerida.edu.mx"
-            autocomplete="email"
-          />
-          <?php if (!empty($errors['email'])): ?>
-            <p class="mt-2 text-xs font-medium text-red-600"><?= e($errors['email']); ?></p>
-          <?php endif; ?>
-        </div>
+      <div class="surface-card px-6 py-8 sm:px-8">
+        <form method="post" action="<?= e(url('/password/change')); ?>" class="space-y-5">
+          <div class="space-y-2">
+            <label for="email" class="text-sm font-semibold text-slate-700">Correo institucional</label>
+            <input
+              id="email"
+              type="email"
+              name="email"
+              value="<?= e($old['email'] ?? ''); ?>"
+              required
+              class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              placeholder="correo@itmerida.edu.mx"
+              autocomplete="email"
+            />
+            <?php if (!empty($errors['email'])): ?>
+              <p class="text-xs font-medium text-rose-600"><?= e($errors['email']); ?></p>
+            <?php endif; ?>
+          </div>
 
-        <div>
-          <label for="password" class="mb-2 block text-sm font-semibold text-slate-700">Nueva contrase&ntilde;a</label>
-          <input
-            id="password"
-            type="password"
-            name="password"
-            required
-            minlength="8"
-            class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:border-indigo-500 focus:ring-indigo-200"
-            placeholder="M&iacute;nimo 8 caracteres"
-            autocomplete="new-password"
-          />
-          <?php if (!empty($errors['password'])): ?>
-            <p class="mt-2 text-xs font-medium text-red-600"><?= e($errors['password']); ?></p>
-          <?php endif; ?>
-        </div>
+          <div class="space-y-2">
+            <label for="password" class="text-sm font-semibold text-slate-700">Nueva contrase&ntilde;a</label>
+            <input
+              id="password"
+              type="password"
+              name="password"
+              required
+              minlength="8"
+              class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              placeholder="M&iacute;nimo 8 caracteres"
+              autocomplete="new-password"
+            />
+            <?php if (!empty($errors['password'])): ?>
+              <p class="text-xs font-medium text-rose-600"><?= e($errors['password']); ?></p>
+            <?php endif; ?>
+          </div>
 
-        <div>
-          <label for="password_confirmation" class="mb-2 block text-sm font-semibold text-slate-700">Confirma tu nueva contrase&ntilde;a</label>
-          <input
-            id="password_confirmation"
-            type="password"
-            name="password_confirmation"
-            required
-            class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:border-indigo-500 focus:ring-indigo-200"
-            placeholder="Repite la contrase&ntilde;a"
-            autocomplete="new-password"
-          />
-          <?php if (!empty($errors['password_confirmation'])): ?>
-            <p class="mt-2 text-xs font-medium text-red-600"><?= e($errors['password_confirmation']); ?></p>
-          <?php endif; ?>
-        </div>
+          <div class="space-y-2">
+            <label for="password_confirmation" class="text-sm font-semibold text-slate-700">Confirma tu nueva contrase&ntilde;a</label>
+            <input
+              id="password_confirmation"
+              type="password"
+              name="password_confirmation"
+              required
+              class="block w-full rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              placeholder="Repite la contrase&ntilde;a"
+              autocomplete="new-password"
+            />
+            <?php if (!empty($errors['password_confirmation'])): ?>
+              <p class="text-xs font-medium text-rose-600"><?= e($errors['password_confirmation']); ?></p>
+            <?php endif; ?>
+          </div>
 
-        <button type="submit" class="w-full rounded-xl bg-[#1869db] px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-[#155cc1] focus:outline-none focus:ring-2 focus:ring-indigo-200">
-          Actualizar contrase&ntilde;a
-        </button>
-      </form>
+          <button type="submit" class="w-full rounded-xl bg-indigo-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200">
+            Actualizar contrase&ntilde;a
+          </button>
+        </form>
+      </div>
 
-      <div class="mt-6 text-center">
-        <a href="<?= e(url('/')); ?>" class="text-sm font-semibold text-[#1869db] hover:text-[#155cc1]">Volver a iniciar sesi&oacute;n</a>
+      <div class="text-center">
+        <a href="<?= e(url('/')); ?>" class="text-sm font-semibold text-indigo-600 transition hover:text-indigo-700">Volver a iniciar sesi&oacute;n</a>
       </div>
     </div>
   </div>

--- a/app/Views/dashboard/components/layout/head.php
+++ b/app/Views/dashboard/components/layout/head.php
@@ -22,5 +22,19 @@ $titleSuffix = isset($pageTitle) && $pageTitle ? 'Gestor de Titulación - ' . $p
     .scrollbar-thin { scrollbar-width: thin; }
     .scrollbar-thin::-webkit-scrollbar { width: 6px; }
     .scrollbar-thin::-webkit-scrollbar-thumb { background-color: rgba(148, 163, 184, .6); border-radius: 9999px; }
+    .layout-shell { background-color: #f8fafc; }
+    .dark .layout-shell { background-color: #020617; }
+    .surface { border-radius: 22px; border: 1px solid rgba(15, 23, 42, 0.08); background: rgba(255, 255, 255, 0.92); box-shadow: 0 24px 60px -36px rgba(15, 23, 42, 0.4); backdrop-filter: blur(10px); }
+    .dark .surface { border-color: rgba(71, 85, 105, 0.55); background: rgba(15, 23, 42, 0.7); box-shadow: 0 24px 60px -36px rgba(15, 23, 42, 0.65); }
+    .surface-muted { border-radius: 18px; border: 1px solid rgba(148, 163, 184, 0.18); background: rgba(248, 250, 252, 0.85); }
+    .dark .surface-muted { border-color: rgba(71, 85, 105, 0.55); background: rgba(15, 23, 42, 0.6); }
+    .surface-table { border-radius: 22px; border: 1px solid rgba(15, 23, 42, 0.08); background: rgba(255, 255, 255, 0.92); box-shadow: 0 18px 50px -32px rgba(15, 23, 42, 0.45); overflow: hidden; }
+    .dark .surface-table { border-color: rgba(71, 85, 105, 0.55); background: rgba(15, 23, 42, 0.75); box-shadow: 0 24px 50px -32px rgba(15, 23, 42, 0.75); }
+    .section-title { font-size: 0.95rem; font-weight: 600; color: #0f172a; }
+    .dark .section-title { color: #e2e8f0; }
+    .section-subtitle { font-size: 0.75rem; color: #64748b; }
+    .dark .section-subtitle { color: #94a3b8; }
+    .badge-soft { display: inline-flex; align-items: center; justify-content: center; border-radius: 999px; padding: 0.125rem 0.625rem; font-size: 0.7rem; font-weight: 600; letter-spacing: 0.02em; background-color: rgba(148, 163, 184, 0.15); color: #475569; }
+    .dark .badge-soft { background-color: rgba(148, 163, 184, 0.22); color: #cbd5f5; }
   </style>
 </head>

--- a/app/Views/dashboard/components/layout/header.php
+++ b/app/Views/dashboard/components/layout/header.php
@@ -1,40 +1,40 @@
-<header class="sticky top-0 z-40 border-b border-slate-200/70 bg-white/90 backdrop-blur dark:border-slate-800 dark:bg-slate-900/80">
-  <div class="flex h-14 items-center gap-3 px-3 sm:px-4">
-    <button id="btnSidebar" class="inline-flex h-9 w-9 items-center justify-center rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800" aria-label="Mostrar u ocultar la navegacion">
+<header class="sticky top-0 z-40 border-b border-transparent bg-white/90 backdrop-blur shadow-[0_1px_0_rgba(148,163,184,0.25)] dark:bg-slate-900/80 dark:shadow-[0_1px_0_rgba(30,41,59,0.65)]">
+  <div class="flex h-14 items-center gap-3 px-4 sm:px-6">
+    <button id="btnSidebar" class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200/70 bg-white/70 text-slate-500 transition hover:border-indigo-200 hover:text-indigo-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300" aria-label="Mostrar u ocultar la navegacion">
       <i data-lucide="menu" class="h-5 w-5"></i>
     </button>
 
-    <div class="flex items-center gap-2 font-semibold">
-      <span class="rounded-lg bg-indigo-600 px-2 py-0.5 text-white">GT</span>
-      <span class="hidden text-sm sm:inline">Gestor de Titulacion</span>
+    <div class="flex items-center gap-2 font-semibold text-slate-700 dark:text-slate-200">
+      <span class="rounded-lg bg-indigo-600/90 px-2.5 py-1 text-xs text-white">GT</span>
+      <span class="hidden text-sm sm:inline">Gestor de Titulación</span>
     </div>
 
     <div class="mx-3 hidden flex-1 items-center sm:flex">
       <label class="relative w-full max-w-xl">
         <i data-lucide="search" class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400"></i>
         <span class="sr-only">Buscar</span>
-        <input type="text" placeholder="Buscar proyecto, hito, comentario..." class="w-full rounded-xl border border-slate-200 bg-slate-50 pl-9 pr-3 py-2 text-sm outline-none placeholder:text-slate-400 focus:border-indigo-500 focus:bg-white dark:border-slate-700 dark:bg-slate-800 dark:focus:border-indigo-400" />
+        <input type="text" placeholder="Buscar proyecto, hito, comentario..." class="w-full rounded-xl border border-slate-200/70 bg-white/70 pl-10 pr-3 py-2 text-sm text-slate-600 placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:placeholder:text-slate-500" />
       </label>
     </div>
 
-    <div class="ml-auto flex items-center gap-1 sm:gap-2">
-      <button class="relative inline-flex h-9 w-9 items-center justify-center rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800" aria-label="Notificaciones">
+    <div class="ml-auto flex items-center gap-2">
+      <button class="relative inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200/70 bg-white/70 text-slate-500 transition hover:border-indigo-200 hover:text-indigo-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300" aria-label="Notificaciones">
         <i data-lucide="bell" class="h-5 w-5"></i>
         <span class="absolute right-1 top-1 h-2 w-2 rounded-full bg-rose-500"></span>
       </button>
 
-      <div class="inline-flex overflow-hidden rounded-xl border border-slate-200 dark:border-slate-800" role="group" aria-label="Cambiar tema">
-        <button id="btnLight" class="flex h-9 w-9 items-center justify-center" title="Modo claro">
+      <div class="inline-flex overflow-hidden rounded-xl border border-slate-200/70 bg-white/70 text-slate-500 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300" role="group" aria-label="Cambiar tema">
+        <button id="btnLight" class="flex h-10 w-10 items-center justify-center" title="Modo claro">
           <i data-lucide="sun" class="h-5 w-5"></i>
           <span class="sr-only">Modo claro</span>
         </button>
-        <button id="btnDark" class="flex h-9 w-9 items-center justify-center" title="Modo oscuro">
+        <button id="btnDark" class="flex h-10 w-10 items-center justify-center" title="Modo oscuro">
           <i data-lucide="moon" class="h-5 w-5"></i>
           <span class="sr-only">Modo oscuro</span>
         </button>
       </div>
 
-      <div class="ml-1 flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm dark:border-slate-800 dark:bg-slate-900">
+      <div class="ml-1 flex items-center gap-2 rounded-xl border border-slate-200/70 bg-white/70 px-2 py-1.5 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200">
         <?php if (!empty($avatarUrl)): ?>
           <img src="<?= e($avatarUrl); ?>" alt="Foto de perfil" class="h-7 w-7 rounded-full object-cover" />
         <?php else: ?>
@@ -43,7 +43,7 @@
           </span>
         <?php endif; ?>
         <div class="hidden leading-tight sm:block">
-          <p class="text-xs font-medium"><?= e($fullName); ?></p>
+          <p class="text-xs font-medium text-slate-700 dark:text-slate-200"><?= e($fullName); ?></p>
           <p class="text-[10px] text-slate-500 dark:text-slate-400"><?= e(ucfirst($role)); ?></p>
         </div>
       </div>

--- a/app/Views/dashboard/components/layout/main.php
+++ b/app/Views/dashboard/components/layout/main.php
@@ -1,5 +1,5 @@
 <?php $_dashboard = get_defined_vars(); ?>
-<main class="min-h-[calc(100vh-3.5rem)] flex-1 p-3 sm:p-6">
+<main class="min-h-[calc(100vh-3.5rem)] flex-1 px-4 py-6 sm:px-8 sm:py-8">
   <?php dashboard_layout('page-heading', $_dashboard); ?>
   <?php dashboard_component('shared/alerts', $_dashboard); ?>
 

--- a/app/Views/dashboard/components/layout/page-heading.php
+++ b/app/Views/dashboard/components/layout/page-heading.php
@@ -1,7 +1,7 @@
-<div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+<div class="mb-8 flex flex-wrap items-center justify-between gap-3">
   <div>
-    <h1 id="pageTitle" class="text-xl font-semibold sm:text-2xl"><?= e($pageTitle ?? 'Panel'); ?></h1>
-    <p id="pageSubtitle" class="mt-0.5 text-xs text-slate-500 dark:text-slate-400"><?= e($pageSubtitle ?? 'Resumen general y acciones rápidas'); ?></p>
+    <h1 id="pageTitle" class="text-2xl font-semibold text-slate-900 sm:text-3xl dark:text-slate-100"><?= e($pageTitle ?? 'Panel'); ?></h1>
+    <p id="pageSubtitle" class="mt-1 text-sm text-slate-500 dark:text-slate-400"><?= e($pageSubtitle ?? 'Resumen general y acciones rápidas'); ?></p>
   </div>
   <form method="post" action="<?= e(url('/logout')); ?>" id="logoutForm" class="hidden"></form>
 </div>

--- a/app/Views/dashboard/components/layout/page.php
+++ b/app/Views/dashboard/components/layout/page.php
@@ -2,7 +2,7 @@
 <!doctype html>
 <html lang="es" class="h-full">
 <?php dashboard_layout('head', $_dashboard); ?>
-<body class="h-full bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+<body class="layout-shell h-full text-slate-900 antialiased dark:text-slate-100">
   <?php dashboard_layout('header', $_dashboard); ?>
 
   <div class="flex w-full gap-0">

--- a/app/Views/dashboard/components/layout/sidebar.php
+++ b/app/Views/dashboard/components/layout/sidebar.php
@@ -1,15 +1,16 @@
 ﻿<?php
 $active = $activeTab ?? 'dashboard';
 ?>
-<aside id="sidebar" class="sticky top-14 hidden h-[calc(100vh-3.5rem)] shrink-0 border-r border-slate-200 bg-white p-2 transition-width duration-300 dark:border-slate-800 dark:bg-slate-900 md:block w-64" aria-label="Navegacion principal">
-  <nav class="flex h-full flex-col">
-    <ul class="flex-1 space-y-1" id="navList">
+<aside id="sidebar" class="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-64 shrink-0 transition-width duration-300 md:block" aria-label="Navegacion principal">
+  <div class="surface h-full p-3">
+    <nav class="flex h-full flex-col">
+      <ul class="flex-1 space-y-1" id="navList">
       <?php foreach ($navItems as $item): ?>
         <?php $isActive = $item['id'] === $active; ?>
         <li>
           <button
             type="button"
-            class="group flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-[13px] font-medium tracking-tight transition <?= $isActive ? 'bg-indigo-600 text-white shadow-sm' : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'; ?>"
+            class="group flex w-full items-center gap-3 rounded-xl px-3.5 py-2.5 text-left text-[13px] font-medium tracking-tight transition <?= $isActive ? 'bg-indigo-600 text-white shadow-sm shadow-indigo-300/40' : 'text-slate-600 hover:bg-slate-100/80 dark:text-slate-300 dark:hover:bg-slate-800/60'; ?>"
             data-nav-btn
             data-nav-target="<?= e($item['id']); ?>"
             data-nav-title="<?= e($item['title']); ?>"
@@ -20,21 +21,22 @@ $active = $activeTab ?? 'dashboard';
           </button>
         </li>
       <?php endforeach; ?>
-    </ul>
+      </ul>
 
-    <div class="space-y-1 pt-1">
-      <button class="side-item flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-[13px] text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800" type="button" data-modal="modalProfile">
-        <i data-lucide="settings" class="icon h-5 w-5 flex-none"></i>
-        <span class="label">Configuracion</span>
-      </button>
-      <button class="side-item flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-[13px] text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800" type="button">
-        <i data-lucide="help-circle" class="icon h-5 w-5 flex-none"></i>
-        <span class="label">Ayuda</span>
-      </button>
-      <button class="side-item flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-[13px] text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800" type="button" data-action="logout">
-        <i data-lucide="log-out" class="icon h-5 w-5 flex-none"></i>
-        <span class="label">Salir</span>
-      </button>
-    </div>
-  </nav>
+      <div class="space-y-1 pt-1">
+        <button class="flex w-full items-center gap-3 rounded-xl px-3.5 py-2.5 text-left text-[13px] text-slate-600 transition hover:bg-slate-100/80 dark:text-slate-300 dark:hover:bg-slate-800/60" type="button" data-modal="modalProfile">
+          <i data-lucide="settings" class="h-5 w-5 flex-none"></i>
+          <span class="label">Configuración</span>
+        </button>
+        <button class="flex w-full items-center gap-3 rounded-xl px-3.5 py-2.5 text-left text-[13px] text-slate-600 transition hover:bg-slate-100/80 dark:text-slate-300 dark:hover:bg-slate-800/60" type="button">
+          <i data-lucide="help-circle" class="h-5 w-5 flex-none"></i>
+          <span class="label">Ayuda</span>
+        </button>
+        <button class="flex w-full items-center gap-3 rounded-xl px-3.5 py-2.5 text-left text-[13px] text-slate-600 transition hover:bg-rose-50/80 hover:text-rose-600 dark:text-slate-300 dark:hover:bg-rose-900/30" type="button" data-action="logout">
+          <i data-lucide="log-out" class="h-5 w-5 flex-none"></i>
+          <span class="label">Salir</span>
+        </button>
+      </div>
+    </nav>
+  </div>
 </aside>

--- a/app/Views/dashboard/components/sections/comments.php
+++ b/app/Views/dashboard/components/sections/comments.php
@@ -1,24 +1,24 @@
 <?php $isCommentsActive = ($activeTab ?? 'dashboard') === 'comentarios'; ?>
-<section id="section-comentarios" data-section="comentarios" class="mt-8 space-y-6<?= $isCommentsActive ? '' : ' hidden'; ?>">
-  <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+<section id="section-comentarios" data-section="comentarios" class="mt-10 space-y-6<?= $isCommentsActive ? '' : ' hidden'; ?>">
+  <article class="surface p-6">
     <div class="space-y-4">
       <?php if ($projectMilestones === []): ?>
         <p class="text-sm text-slate-500">Selecciona un proyecto con hitos para ver los comentarios.</p>
       <?php else: ?>
         <?php foreach ($projectMilestones as $milestone): ?>
           <?php $feedbackList = $feedbackByMilestone[$milestone['id']] ?? []; ?>
-          <section class="rounded-xl border border-slate-200 bg-white/80 p-4 dark:border-slate-800 dark:bg-slate-900/40">
+          <section class="surface-muted p-4">
             <div class="flex items-center justify-between">
-              <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Hito: <?= e($milestone['title']); ?></h3>
-              <span class="rounded-lg bg-slate-100 px-2 py-0.5 text-[11px] text-slate-500 dark:bg-slate-800">Comentarios: <?= e((string) count($feedbackList)); ?></span>
+              <h3 class="text-base font-semibold text-slate-800 dark:text-slate-100">Hito: <?= e($milestone['title']); ?></h3>
+              <span class="badge-soft">Comentarios: <?= e((string) count($feedbackList)); ?></span>
             </div>
             <div class="mt-3 space-y-3">
               <?php if ($feedbackList === []): ?>
                 <p class="text-xs text-slate-500">Sin comentarios registrados.</p>
               <?php else: ?>
                 <?php foreach ($feedbackList as $comment): ?>
-                  <article class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm dark:border-slate-800 dark:bg-slate-900">
-                    <div class="flex items-center justify-between text-xs text-slate-400">
+                  <article class="surface px-3 py-2 text-sm dark:text-slate-200">
+                    <div class="flex items-center justify-between text-xs text-slate-400 dark:text-slate-500">
                       <span class="font-semibold text-slate-600 dark:text-slate-200"><?= e($comment['author_name']); ?></span>
                       <span><?= e(format_dashboard_date($comment['created_at'] ?? null)); ?></span>
                     </div>

--- a/app/Views/dashboard/components/sections/dashboard-overview.php
+++ b/app/Views/dashboard/components/sections/dashboard-overview.php
@@ -27,37 +27,37 @@ $statCards = [
     ],
 ];
 ?>
-<section id="section-dashboard" data-section="dashboard" class="space-y-6<?= $isDashboardActive ? '' : ' hidden'; ?>">
-  <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+<section id="section-dashboard" data-section="dashboard" class="space-y-8<?= $isDashboardActive ? '' : ' hidden'; ?>">
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
     <?php foreach ($statCards as $card): ?>
-      <article class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <article class="surface p-5">
         <div class="flex items-center justify-between">
-          <p class="text-xs font-medium uppercase tracking-wide text-slate-500"><?= e($card['label']); ?></p>
+          <p class="text-xs font-medium uppercase tracking-wide text-slate-500/80 dark:text-slate-400/90"><?= e($card['label']); ?></p>
           <i data-lucide="<?= e($card['icon']); ?>" class="h-5 w-5 <?= e($card['accent']); ?>"></i>
         </div>
-        <p class="mt-4 text-3xl font-semibold"><?= e((string) $card['value']); ?></p>
+        <p class="mt-5 text-3xl font-semibold text-slate-900 dark:text-slate-100"><?= e((string) $card['value']); ?></p>
       </article>
     <?php endforeach; ?>
   </div>
 
-  <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
-    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+  <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+    <article class="surface p-6">
       <div class="flex items-center justify-between">
-        <h2 class="text-base font-semibold">Próximos hitos</h2>
-        <span class="text-xs text-slate-500"><?= e((string) count($upcomingMilestones)); ?> pendientes</span>
+        <h2 class="section-title">Próximos hitos</h2>
+        <span class="badge-soft"><?= e((string) count($upcomingMilestones)); ?> pendientes</span>
       </div>
-      <div class="mt-4 space-y-3">
+      <div class="mt-5 space-y-3">
         <?php if ($upcomingMilestones === []): ?>
           <p class="text-sm text-slate-500">Sin hitos programados en los próximos días.</p>
         <?php else: ?>
           <?php foreach ($upcomingMilestones as $item): ?>
-            <div class="rounded-xl border border-slate-200/70 bg-slate-50 px-3 py-3 text-sm dark:border-slate-800 dark:bg-slate-900">
+            <div class="surface-muted px-3 py-3 text-sm dark:text-slate-200">
               <div class="flex items-center justify-between gap-3">
                 <div>
                   <p class="font-medium text-slate-800 dark:text-slate-100"><?= e($item['title']); ?></p>
                   <p class="text-xs text-slate-500">Proyecto: <?= e($item['project_title']); ?></p>
                 </div>
-                <span class="rounded-lg bg-indigo-100 px-2 py-1 text-[11px] font-medium text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-200">
+                <span class="badge-soft text-indigo-600 dark:text-indigo-200">
                   <?= e(format_dashboard_date($item['due_date'] ?? null)); ?>
                 </span>
               </div>
@@ -67,17 +67,17 @@ $statCards = [
       </div>
     </article>
 
-    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <article class="surface p-6">
       <div class="flex items-center justify-between">
-        <h2 class="text-base font-semibold">Feedback reciente</h2>
-        <span class="text-xs text-slate-500"><?= e((string) count($recentFeedback)); ?> registros</span>
+        <h2 class="section-title">Feedback reciente</h2>
+        <span class="badge-soft"><?= e((string) count($recentFeedback)); ?> registros</span>
       </div>
-      <div class="mt-4 space-y-3">
+      <div class="mt-5 space-y-3">
         <?php if ($recentFeedback === []): ?>
           <p class="text-sm text-slate-500">Aún no hay comentarios registrados.</p>
         <?php else: ?>
           <?php foreach ($recentFeedback as $comment): ?>
-            <div class="rounded-xl border border-slate-200/70 px-3 py-3 text-sm dark:border-slate-800">
+            <div class="surface-muted px-3 py-3 text-sm dark:text-slate-200">
               <div class="flex items-center justify-between gap-2">
                 <p class="font-medium text-slate-800 dark:text-slate-100">
                   <?= e($comment['author_name']); ?>

--- a/app/Views/dashboard/components/sections/milestones.php
+++ b/app/Views/dashboard/components/sections/milestones.php
@@ -1,22 +1,22 @@
 <?php $isMilestonesActive = ($activeTab ?? 'dashboard') === 'hitos'; ?>
-<section id="section-hitos" data-section="hitos" class="mt-8 space-y-6<?= $isMilestonesActive ? '' : ' hidden'; ?>">
+<section id="section-hitos" data-section="hitos" class="mt-10 space-y-6<?= $isMilestonesActive ? '' : ' hidden'; ?>">
   <?php if (!$selectedProject): ?>
-    <div class="rounded-2xl border border-slate-200 bg-white px-5 py-10 text-center text-sm text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="surface px-6 py-10 text-center text-sm text-slate-500 dark:text-slate-300">
       Selecciona un proyecto para gestionar sus hitos.
     </div>
   <?php else: ?>
-    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <article class="surface space-y-5 p-6">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h3 class="text-base font-semibold text-slate-800 dark:text-slate-100"><?= e($selectedProject['title']); ?></h3>
-          <p class="text-xs text-slate-500">Estudiante: <?= e($selectedProject['student_name']); ?> · Director: <?= e($selectedProject['director_name']); ?></p>
+          <h3 class="text-lg font-semibold text-slate-900 dark:text-slate-100"><?= e($selectedProject['title']); ?></h3>
+          <p class="text-sm text-slate-500">Estudiante: <?= e($selectedProject['student_name']); ?> · Director: <?= e($selectedProject['director_name']); ?></p>
         </div>
-        <span class="rounded-lg px-3 py-1 text-xs font-semibold <?= e(status_badge_classes($selectedProject['status'])); ?>">Estado: <?= e(humanize_status($selectedProject['status'])); ?></span>
+        <span class="rounded-full px-3 py-1 text-xs font-semibold <?= e(status_badge_classes($selectedProject['status'])); ?>">Estado: <?= e(humanize_status($selectedProject['status'])); ?></span>
       </div>
 
-      <div class="mt-6 space-y-4">
+      <div class="space-y-4">
         <?php if ($projectMilestones === []): ?>
-          <div class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900/40">Aún no hay hitos registrados.</div>
+          <div class="surface-muted px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-200">Aún no hay hitos registrados.</div>
         <?php else: ?>
           <?php foreach ($projectMilestones as $milestone): ?>
             <?php
@@ -35,25 +35,25 @@
               $canUploadDeliverable = !empty($isStudentOwner)
                   && !in_array($milestone['status'], ['en_revision', 'aprobado'], true);
             ?>
-            <article class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/60">
-              <div class="flex flex-wrap items-start justify-between gap-3">
+            <article class="surface-muted p-5 text-sm dark:text-slate-200">
+              <div class="flex flex-wrap items-start justify-between gap-4">
                 <div>
-                  <h4 class="text-sm font-semibold text-slate-800 dark:text-slate-100"><?= e($milestone['title']); ?></h4>
-                  <p class="mt-1 text-xs text-slate-500"><?= e($milestone['description'] ?: 'Sin descripción.'); ?></p>
-                  <p class="mt-2 text-xs text-slate-400">Entrega: <?= e(format_dashboard_date($milestone['due_date'] ?? null)); ?></p>
+                  <h4 class="text-base font-semibold text-slate-800 dark:text-slate-100"><?= e($milestone['title']); ?></h4>
+                  <p class="mt-2 text-sm text-slate-500"><?= e($milestone['description'] ?: 'Sin descripción.'); ?></p>
+                  <p class="mt-3 text-xs text-slate-400">Entrega: <?= e(format_dashboard_date($milestone['due_date'] ?? null)); ?></p>
                 </div>
                 <div class="flex flex-wrap items-center gap-2">
-                  <span class="rounded-lg px-2 py-1 text-[11px] font-semibold <?= e(status_badge_classes($milestone['status'])); ?>"><?= e(humanize_status($milestone['status'])); ?></span>
+                  <span class="rounded-full px-2.5 py-1 text-[11px] font-semibold <?= e(status_badge_classes($milestone['status'])); ?>"><?= e(humanize_status($milestone['status'])); ?></span>
                   <?php if ($statusOptions !== []): ?>
                     <form method="post" action="<?= e(url('/milestones/status')); ?>" class="flex items-center gap-1">
                       <input type="hidden" name="milestone_id" value="<?= e((string) $milestone['id']); ?>" />
                       <label class="sr-only" for="milestone-status-<?= e((string) $milestone['id']); ?>">Estado</label>
-                      <select id="milestone-status-<?= e((string) $milestone['id']); ?>" name="status" class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs outline-none dark:border-slate-700 dark:bg-slate-900">
+                      <select id="milestone-status-<?= e((string) $milestone['id']); ?>" name="status" class="rounded-lg border border-slate-200/70 bg-white/90 px-2 py-1 text-xs outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900/60">
                         <?php foreach ($statusOptions as $option): ?>
                           <option value="<?= e($option); ?>" <?= $option === ($milestone['status'] ?? '') ? 'selected' : ''; ?>><?= e(humanize_status($option)); ?></option>
                         <?php endforeach; ?>
                       </select>
-                      <button type="submit" class="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-700">
+                      <button type="submit" class="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-2.5 py-1 text-xs font-semibold text-white transition hover:bg-indigo-700">
                         <i data-lucide="save" class="h-3.5 w-3.5"></i>
                       </button>
                     </form>
@@ -61,46 +61,46 @@
                 </div>
               </div>
 
-              <div class="mt-4 grid gap-4 lg:grid-cols-2">
-                <section class="rounded-lg border border-slate-200 bg-slate-50 p-4 text-xs dark:border-slate-800 dark:bg-slate-900/40">
+              <div class="mt-5 grid gap-4 lg:grid-cols-2">
+                <section class="surface p-4 text-xs dark:text-slate-200">
                   <div class="flex items-center justify-between">
                     <p class="font-semibold text-slate-700 dark:text-slate-200">Entregables</p>
-                    <span class="rounded-lg bg-indigo-100 px-2 py-0.5 text-[11px] font-semibold text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-200">
+                    <span class="badge-soft text-indigo-600 dark:text-indigo-200">
                       <?= e((string) ($milestone['deliverables_count'] ?? 0)); ?>
                     </span>
                   </div>
-                  <div class="mt-3 max-h-40 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
+                  <div class="mt-4 max-h-40 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
                     <?php if ($deliverables === []): ?>
                       <p class="text-slate-500">Sin entregas aún.</p>
                     <?php else: ?>
                       <?php foreach ($deliverables as $deliverable): ?>
-                        <article class="rounded-lg bg-white/80 px-3 py-2 shadow-sm ring-1 ring-slate-200 dark:bg-slate-950/30 dark:ring-slate-800">
+                        <article class="surface-muted px-3 py-2 text-left">
                           <p class="text-slate-700 dark:text-slate-200"><?= e($deliverable['original_name']); ?></p>
                           <p class="text-[11px] text-slate-400">Autor: <?= e($deliverable['author_name']); ?></p>
                           <div class="mt-1 flex items-center justify-between text-[11px] text-slate-400">
                             <span><?= e($deliverable['notes'] ? 'Notas incluidas' : 'Archivo'); ?></span>
                             <?php if (!empty($deliverable['file_path'])): ?>
-                              <a class="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-0.5 text-[11px] text-indigo-600 hover:bg-indigo-50 dark:border-slate-700 dark:text-indigo-300 dark:hover:bg-indigo-900/40" href="<?= e(url('/deliverables/download?id=' . (int) $deliverable['id'])); ?>">
+                              <a class="inline-flex items-center gap-1 rounded-lg border border-slate-200/70 bg-white/80 px-2 py-0.5 text-[11px] text-indigo-600 transition hover:border-indigo-200 hover:text-indigo-700 dark:border-slate-700 dark:bg-slate-900/40 dark:text-indigo-300 dark:hover:border-indigo-400" href="<?= e(url('/deliverables/download?id=' . (int) $deliverable['id'])); ?>">
                                 <i data-lucide="download" class="h-3 w-3"></i> Descargar
                               </a>
                             <?php endif; ?>
                           </div>
                           <?php if (!empty($deliverable['notes'])): ?>
-                            <p class="mt-2 rounded-lg bg-slate-100 px-2 py-1 text-slate-600 dark:bg-slate-800 dark:text-slate-200">"<?= e($deliverable['notes']); ?>"</p>
+                            <p class="mt-2 rounded-lg bg-slate-100/80 px-2 py-1 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">"<?= e($deliverable['notes']); ?>"</p>
                           <?php endif; ?>
                         </article>
                       <?php endforeach; ?>
                     <?php endif; ?>
                   </div>
 
-                  <div class="mt-3">
+                  <div class="mt-4">
                     <?php if ($canUploadDeliverable): ?>
-                      <form method="post" action="<?= e(url('/deliverables')); ?>" enctype="multipart/form-data" class="space-y-2">
+                      <form method="post" action="<?= e(url('/deliverables')); ?>" enctype="multipart/form-data" class="space-y-3">
                         <input type="hidden" name="milestone_id" value="<?= e((string) $milestone['id']); ?>" />
                         <label class="block text-[11px] font-semibold uppercase text-slate-500">Subir avance</label>
-                        <input type="file" name="file" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs dark:border-slate-700 dark:bg-slate-900" />
-                        <textarea name="notes" rows="2" placeholder="Notas complementarias (opcional)" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900"></textarea>
-                        <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3 py-2 text-xs font-medium text-white hover:bg-indigo-700">
+                        <input type="file" name="file" class="w-full rounded-lg border border-slate-200/70 bg-white px-3 py-2 text-xs focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900/60" />
+                        <textarea name="notes" rows="2" placeholder="Notas complementarias (opcional)" class="w-full rounded-lg border border-slate-200/70 bg-white px-3 py-2 text-xs outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900/60"></textarea>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3.5 py-2 text-xs font-semibold text-white transition hover:bg-indigo-700">
                           <i data-lucide="upload" class="h-3.5 w-3.5"></i> Registrar avance
                         </button>
                       </form>
@@ -110,19 +110,19 @@
                   </div>
                 </section>
 
-                <section class="rounded-lg border border-slate-200 bg-slate-50 p-4 text-xs dark:border-slate-800 dark:bg-slate-900/40">
+                <section class="surface p-4 text-xs dark:text-slate-200">
                   <div class="flex items-center justify-between">
                     <p class="font-semibold text-slate-700 dark:text-slate-200">Feedback</p>
-                    <span class="rounded-lg bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 dark:bg-emerald-900/60 dark:text-emerald-200">
+                    <span class="badge-soft text-emerald-600 dark:text-emerald-200">
                       <?= e((string) ($milestone['feedback_count'] ?? 0)); ?>
                     </span>
                   </div>
-                  <div class="mt-3 max-h-40 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
+                  <div class="mt-4 max-h-40 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
                     <?php if ($feedbackList === []): ?>
                       <p class="text-slate-500">Sin comentarios aún.</p>
                     <?php else: ?>
                       <?php foreach ($feedbackList as $comment): ?>
-                        <article class="rounded-lg bg-white/80 px-3 py-2 shadow-sm ring-1 ring-slate-200 dark:bg-slate-950/30 dark:ring-slate-800">
+                        <article class="surface-muted px-3 py-2">
                           <p class="font-semibold text-slate-700 dark:text-slate-200"><?= e($comment['author_name']); ?></p>
                           <p class="mt-1 text-slate-600 dark:text-slate-300">"<?= e($comment['content']); ?>"</p>
                         </article>
@@ -130,10 +130,10 @@
                     <?php endif; ?>
                   </div>
                   <div class="mt-3">
-                    <form method="post" action="<?= e(url('/feedback')); ?>" class="space-y-2">
+                    <form method="post" action="<?= e(url('/feedback')); ?>" class="space-y-3">
                       <input type="hidden" name="milestone_id" value="<?= e((string) $milestone['id']); ?>" />
-                      <textarea name="content" rows="3" placeholder="Escribe un comentario" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900" required></textarea>
-                      <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3 py-2 text-xs font-medium text-white hover:bg-emerald-700">
+                      <textarea name="content" rows="3" placeholder="Escribe un comentario" class="w-full rounded-lg border border-slate-200/70 bg-white px-3 py-2 text-xs outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900/60" required></textarea>
+                      <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3.5 py-2 text-xs font-semibold text-white transition hover:bg-emerald-700">
                         <i data-lucide="message-circle" class="h-3.5 w-3.5"></i> Enviar feedback
                       </button>
                     </form>

--- a/app/Views/dashboard/components/sections/progress.php
+++ b/app/Views/dashboard/components/sections/progress.php
@@ -7,23 +7,23 @@ $boardMap = [
     'aprobado' => 'Aprobado',
 ];
 ?>
-<section id="section-progreso" data-section="progreso" class="mt-8 space-y-6<?= $isProgressActive ? '' : ' hidden'; ?>">
-  <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+<section id="section-progreso" data-section="progreso" class="mt-10 space-y-6<?= $isProgressActive ? '' : ' hidden'; ?>">
+  <div class="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-4">
     <?php foreach ($boardMap as $columnKey => $columnLabel): ?>
       <?php $items = $boardColumns[$columnKey] ?? []; ?>
-      <article class="flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <article class="surface flex h-full flex-col gap-4 p-5">
         <div class="flex items-center justify-between">
           <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-200"><?= e($columnLabel); ?></h3>
-          <span class="rounded-lg bg-slate-100 px-2 py-0.5 text-[11px] text-slate-500 dark:bg-slate-800">
+          <span class="badge-soft">
             <?= e((string) count($items)); ?>
           </span>
         </div>
-        <div class="mt-3 flex-1 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
+        <div class="flex-1 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
           <?php if ($items === []): ?>
             <p class="text-xs text-slate-500">Sin elementos.</p>
           <?php else: ?>
             <?php foreach ($items as $item): ?>
-              <article class="rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs dark:border-slate-800 dark:bg-slate-900/50">
+              <article class="surface-muted p-3 text-xs dark:text-slate-200">
                 <p class="font-semibold text-slate-700 dark:text-slate-100"><?= e($item['title']); ?></p>
                 <p class="mt-1 text-[11px] text-slate-500">Proyecto: <?= e($item['project_title']); ?></p>
                 <p class="mt-2 text-[11px] text-slate-400">Entrega: <?= e(format_dashboard_date($item['due_date'] ?? null)); ?></p>

--- a/app/Views/dashboard/components/sections/projects.php
+++ b/app/Views/dashboard/components/sections/projects.php
@@ -1,17 +1,17 @@
 <?php $isProjectsActive = ($activeTab ?? 'dashboard') === 'proyectos'; ?>
-<section id="section-proyectos" data-section="proyectos" class="mt-8 space-y-6<?= $isProjectsActive ? '' : ' hidden'; ?>">
+<section id="section-proyectos" data-section="proyectos" class="mt-10 space-y-6<?= $isProjectsActive ? '' : ' hidden'; ?>">
   <div class="flex flex-wrap items-center justify-end gap-3">
     <?php if (!empty($isDirector)): ?>
-      <button data-modal="modalProject" type="button" class="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 focus:outline-none">
+      <button data-modal="modalProject" type="button" class="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200">
         <i data-lucide="plus" class="h-4 w-4"></i> Nuevo proyecto
       </button>
     <?php endif; ?>
   </div>
 
-  <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-    <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
-      <thead class="bg-slate-50 dark:bg-slate-900/70">
-        <tr class="text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+  <div class="surface-table">
+    <table class="min-w-full divide-y divide-slate-200/70 text-sm dark:divide-slate-800/70">
+      <thead class="bg-white/70 dark:bg-slate-900/60">
+        <tr class="text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
           <th class="px-4 py-3">Proyecto</th>
           <th class="px-4 py-3">Estudiante</th>
           <th class="px-4 py-3">Estado</th>
@@ -19,7 +19,7 @@
           <th class="px-4 py-3 text-right">Acciones</th>
         </tr>
       </thead>
-      <tbody class="divide-y divide-slate-100 dark:divide-slate-800">
+      <tbody class="divide-y divide-slate-100/80 dark:divide-slate-800/70">
         <?php if ($projects === []): ?>
           <tr>
             <td colspan="5" class="px-4 py-6 text-center text-sm text-slate-500">Aún no se registran proyectos.</td>
@@ -27,7 +27,7 @@
         <?php else: ?>
           <?php foreach ($projects as $project): ?>
             <?php $isProjectDirector = !empty($isDirector) && (int) ($project['director_id'] ?? 0) === $userId; ?>
-            <tr class="hover:bg-slate-50/80 dark:hover:bg-slate-800/40">
+            <tr class="transition hover:bg-slate-50/70 dark:hover:bg-slate-800/40">
               <td class="px-4 py-3">
                 <div class="font-medium text-slate-800 dark:text-slate-100"><?= e($project['title']); ?></div>
                 <div class="text-xs text-slate-500">Director: <?= e($project['director_name']); ?></div>
@@ -37,7 +37,7 @@
                 <div class="text-[11px] text-slate-400"><?= e($project['student_email']); ?></div>
               </td>
               <td class="px-4 py-3">
-                <span class="inline-flex items-center rounded-lg px-2 py-1 text-xs font-semibold <?= e(status_badge_classes($project['status'])); ?>">
+                <span class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold <?= e(status_badge_classes($project['status'])); ?>">
                   <?= e(humanize_status($project['status'])); ?>
                 </span>
               </td>
@@ -46,19 +46,19 @@
               </td>
               <td class="px-4 py-3 text-right">
                 <div class="flex justify-end gap-2">
-                  <a class="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-1 text-xs text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800" href="<?= e(url('/dashboard?tab=proyectos&project=' . (int) $project['id'])); ?>">
+                  <a class="inline-flex items-center gap-1 rounded-lg border border-slate-200/70 bg-white/70 px-2.5 py-1 text-xs text-slate-600 transition hover:border-indigo-200 hover:text-indigo-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-indigo-400" href="<?= e(url('/dashboard?tab=proyectos&project=' . (int) $project['id'])); ?>">
                     <i data-lucide="eye" class="h-3.5 w-3.5"></i> Ver
                   </a>
                   <?php if ($isProjectDirector): ?>
                     <form method="post" action="<?= e(url('/projects/status')); ?>" class="inline-flex items-center gap-1">
                       <input type="hidden" name="project_id" value="<?= e((string) $project['id']); ?>" />
                       <label class="sr-only" for="project-status-<?= e((string) $project['id']); ?>">Estado</label>
-                      <select id="project-status-<?= e((string) $project['id']); ?>" name="status" class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs outline-none dark:border-slate-700 dark:bg-slate-900">
+                      <select id="project-status-<?= e((string) $project['id']); ?>" name="status" class="rounded-lg border border-slate-200/70 bg-white/80 px-2 py-1 text-xs outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900/60">
                         <?php foreach (['planificado','en_progreso','en_riesgo','completado'] as $statusOption): ?>
                           <option value="<?= e($statusOption); ?>" <?= $statusOption === $project['status'] ? 'selected' : ''; ?>><?= e(humanize_status($statusOption)); ?></option>
                         <?php endforeach; ?>
                       </select>
-                      <button type="submit" class="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-700">
+                      <button type="submit" class="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-2.5 py-1 text-xs font-semibold text-white transition hover:bg-indigo-700">
                         <i data-lucide="save" class="h-3.5 w-3.5"></i>
                       </button>
                     </form>

--- a/app/Views/dashboard/components/shared/alerts.php
+++ b/app/Views/dashboard/components/shared/alerts.php
@@ -1,13 +1,13 @@
 <?php if ($success): ?>
-  <div class="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-100">
+  <div class="mb-6 rounded-2xl border border-emerald-200/70 bg-emerald-50/80 px-5 py-4 text-sm text-emerald-700 dark:border-emerald-800/70 dark:bg-emerald-900/40 dark:text-emerald-100">
     <?= e($success); ?>
   </div>
 <?php endif; ?>
 
 <?php if ($errors): ?>
-  <div class="mb-4 space-y-2">
+  <div class="mb-6 space-y-2">
     <?php foreach ($errors as $error): ?>
-      <div class="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-800 dark:bg-rose-900/40 dark:text-rose-100">
+      <div class="rounded-2xl border border-rose-200/70 bg-rose-50/80 px-5 py-4 text-sm text-rose-600 dark:border-rose-800/70 dark:bg-rose-900/40 dark:text-rose-100">
         <?= e($error); ?>
       </div>
     <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Rediseñar la pantalla de autenticación con un layout minimalista, superficies suaves y formularios más claros.
- Actualizar la vista de recuperación de contraseña para alinearla con el nuevo estilo y jerarquía visual.
- Aplicar el mismo lenguaje visual en el tablero: encabezado, barra lateral y secciones usan superficies ligeras, espaciado consistente y badges suaves.

## Testing
- php -l app/Views/auth/index.php
- php -l app/Views/auth/password_change.php
- php -l app/Views/dashboard/components/layout/head.php
- php -l app/Views/dashboard/components/sections/projects.php
- php -l app/Views/dashboard/components/sections/milestones.php


------
https://chatgpt.com/codex/tasks/task_e_68dcc7d18d28832e840530653c9e2623