### PR TITLE
Refine dashboard modules layout and styling

### DIFF
--- a/app/Views/dashboard/components/layout/main.php
+++ b/app/Views/dashboard/components/layout/main.php
@@ -3,9 +3,11 @@
   <?php dashboard_layout('page-heading', $_dashboard); ?>
   <?php dashboard_component('shared/alerts', $_dashboard); ?>
 
-  <?php dashboard_section('dashboard-overview', $_dashboard); ?>
-  <?php dashboard_section('projects', $_dashboard); ?>
-  <?php dashboard_section('milestones', $_dashboard); ?>
-  <?php dashboard_section('comments', $_dashboard); ?>
-  <?php dashboard_section('progress', $_dashboard); ?>
+  <div class="space-y-8">
+    <?php dashboard_section('dashboard-overview', $_dashboard); ?>
+    <?php dashboard_section('projects', $_dashboard); ?>
+    <?php dashboard_section('milestones', $_dashboard); ?>
+    <?php dashboard_section('comments', $_dashboard); ?>
+    <?php dashboard_section('progress', $_dashboard); ?>
+  </div>
 </main>

--- a/app/Views/dashboard/components/sections/comments.php
+++ b/app/Views/dashboard/components/sections/comments.php
@@ -1,28 +1,35 @@
 <?php $isCommentsActive = ($activeTab ?? 'dashboard') === 'comentarios'; ?>
-<section id="section-comentarios" data-section="comentarios" class="space-y-6<?= $isCommentsActive ? '' : ' hidden'; ?>">
-  <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-    <div class="space-y-5">
+<section id="section-comentarios" data-section="comentarios" class="space-y-8<?= $isCommentsActive ? '' : ' hidden'; ?>">
+  <article class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200/70 dark:bg-slate-900 dark:ring-slate-800">
+    <header class="flex flex-wrap items-start justify-between gap-3">
+      <div class="space-y-1">
+        <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Comentarios por hito</h2>
+        <p class="text-sm text-slate-500 dark:text-slate-400">Consulta la retroalimentación registrada para cada avance y mantén a tu equipo informado.</p>
+      </div>
+    </header>
+
+    <div class="mt-6 space-y-5">
       <?php if ($projectMilestones === []): ?>
-        <p class="text-sm text-slate-500">Selecciona un proyecto con hitos para ver los comentarios.</p>
+        <p class="rounded-2xl bg-slate-50 px-4 py-6 text-center text-sm text-slate-500 shadow-inner dark:bg-slate-900/50 dark:text-slate-400">Selecciona un proyecto con hitos para ver los comentarios.</p>
       <?php else: ?>
         <?php foreach ($projectMilestones as $milestone): ?>
           <?php $feedbackList = $feedbackByMilestone[$milestone['id']] ?? []; ?>
-          <section class="rounded-xl bg-slate-50/80 p-4 ring-1 ring-slate-200/70 backdrop-blur-sm dark:bg-slate-900/40 dark:ring-slate-800/70">
+          <section class="rounded-2xl bg-slate-50/80 p-4 ring-1 ring-slate-200/70 backdrop-blur-sm dark:bg-slate-900/40 dark:ring-slate-800/70">
             <div class="flex flex-wrap items-center justify-between gap-3">
               <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Hito: <?= e($milestone['title']); ?></h3>
-              <span class="rounded-lg bg-slate-200/70 px-2 py-0.5 text-[11px] font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-300">Comentarios: <?= e((string) count($feedbackList)); ?></span>
+              <span class="inline-flex items-center rounded-full bg-slate-200/70 px-2.5 py-0.5 text-[11px] font-semibold text-slate-600 dark:bg-slate-800/70 dark:text-slate-300">Comentarios: <?= e((string) count($feedbackList)); ?></span>
             </div>
-            <div class="mt-3 space-y-3">
+            <div class="mt-4 space-y-3">
               <?php if ($feedbackList === []): ?>
-                <p class="text-xs text-slate-500">Sin comentarios registrados.</p>
+                <p class="text-xs text-slate-500 dark:text-slate-400">Sin comentarios registrados.</p>
               <?php else: ?>
                 <?php foreach ($feedbackList as $comment): ?>
-                  <article class="rounded-lg bg-white/80 px-3 py-2 text-sm ring-1 ring-slate-200/70 transition hover:bg-white dark:bg-slate-900/50 dark:ring-slate-800/70">
+                  <article class="rounded-xl bg-white px-3 py-2 text-sm shadow-sm ring-1 ring-slate-200/70 transition hover:ring-indigo-200 dark:bg-slate-900/50 dark:ring-slate-800/70">
                     <div class="flex flex-wrap items-center justify-between gap-2 text-[11px] text-slate-400">
                       <span class="font-semibold text-slate-600 dark:text-slate-200"><?= e($comment['author_name']); ?></span>
                       <span><?= e(format_dashboard_date($comment['created_at'] ?? null)); ?></span>
                     </div>
-                    <p class="mt-1 text-slate-700 dark:text-slate-200"><?= e($comment['content']); ?></p>
+                    <p class="mt-2 text-slate-700 dark:text-slate-200"><?= e($comment['content']); ?></p>
                   </article>
                 <?php endforeach; ?>
               <?php endif; ?>

--- a/app/Views/dashboard/components/sections/dashboard-overview.php
+++ b/app/Views/dashboard/components/sections/dashboard-overview.php
@@ -26,68 +26,94 @@ $statCards = [
         'accent' => 'text-amber-500',
     ],
 ];
+
+$iconStyles = [
+    'text-indigo-500' => 'bg-indigo-50 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-200',
+    'text-emerald-500' => 'bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-200',
+    'text-amber-500' => 'bg-amber-50 text-amber-600 dark:bg-amber-500/10 dark:text-amber-200',
+];
 ?>
-<section id="section-dashboard" data-section="dashboard" class="space-y-6<?= $isDashboardActive ? '' : ' hidden'; ?>">
-  <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+<section id="section-dashboard" data-section="dashboard" class="space-y-8<?= $isDashboardActive ? '' : ' hidden'; ?>">
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
     <?php foreach ($statCards as $card): ?>
-      <article class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-        <div class="flex items-center justify-between">
-          <p class="text-xs font-medium uppercase tracking-wide text-slate-500"><?= e($card['label']); ?></p>
-          <i data-lucide="<?= e($card['icon']); ?>" class="h-5 w-5 <?= e($card['accent']); ?>"></i>
+      <?php $accent = $iconStyles[$card['accent']] ?? 'bg-slate-100 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200'; ?>
+      <article class="flex flex-col gap-5 rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200/70 dark:bg-slate-900 dark:ring-slate-800">
+        <div class="flex items-start justify-between">
+          <div class="space-y-1">
+            <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400"><?= e($card['label']); ?></p>
+            <p class="text-3xl font-semibold text-slate-800 dark:text-slate-100"><?= e((string) $card['value']); ?></p>
+          </div>
+          <span class="inline-flex h-10 w-10 items-center justify-center rounded-xl <?= e($accent); ?>">
+            <i data-lucide="<?= e($card['icon']); ?>" class="h-5 w-5"></i>
+          </span>
         </div>
-        <p class="mt-4 text-3xl font-semibold"><?= e((string) $card['value']); ?></p>
+        <div class="h-1.5 w-full rounded-full bg-slate-100 dark:bg-slate-800">
+          <span class="block h-full rounded-full bg-gradient-to-r from-slate-300/80 via-slate-400/80 to-slate-500/70 dark:from-slate-700 dark:via-slate-600 dark:to-slate-500"></span>
+        </div>
       </article>
     <?php endforeach; ?>
   </div>
 
-  <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
-    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <div class="flex items-center justify-between">
-        <h2 class="text-base font-semibold">Próximos hitos</h2>
-        <span class="text-xs text-slate-500"><?= e((string) count($upcomingMilestones)); ?> pendientes</span>
-      </div>
-      <div class="mt-4 space-y-3">
+  <div class="grid grid-cols-1 gap-5 xl:grid-cols-2">
+    <article class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200/70 dark:bg-slate-900 dark:ring-slate-800">
+      <header class="flex items-start justify-between gap-3">
+        <div>
+          <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Próximos hitos</h2>
+          <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">Controla los compromisos de esta semana para anticiparte a los entregables.</p>
+        </div>
+        <span class="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-200">
+          <?= e((string) count($upcomingMilestones)); ?> pendientes
+        </span>
+      </header>
+      <div class="mt-5">
         <?php if ($upcomingMilestones === []): ?>
-          <p class="text-sm text-slate-500">Sin hitos programados en los próximos días.</p>
+          <p class="rounded-xl bg-slate-50 px-4 py-5 text-sm text-slate-500 dark:bg-slate-900/60 dark:text-slate-400">Sin hitos programados en los próximos días.</p>
         <?php else: ?>
-          <?php foreach ($upcomingMilestones as $item): ?>
-            <div class="rounded-xl border border-slate-200/70 bg-slate-50 px-3 py-3 text-sm dark:border-slate-800 dark:bg-slate-900">
-              <div class="flex items-center justify-between gap-3">
-                <div>
+          <ul class="divide-y divide-slate-100 text-sm dark:divide-slate-800">
+            <?php foreach ($upcomingMilestones as $item): ?>
+              <li class="flex items-start justify-between gap-4 py-4 first:pt-0 last:pb-0">
+                <div class="space-y-1">
                   <p class="font-medium text-slate-800 dark:text-slate-100"><?= e($item['title']); ?></p>
                   <p class="text-xs text-slate-500">Proyecto: <?= e($item['project_title']); ?></p>
                 </div>
-                <span class="rounded-lg bg-indigo-100 px-2 py-1 text-[11px] font-medium text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-200">
+                <span class="inline-flex items-center rounded-lg bg-indigo-100 px-3 py-1 text-[11px] font-semibold text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-200">
                   <?= e(format_dashboard_period($item['start_date'] ?? null, $item['end_date'] ?? ($item['due_date'] ?? null))); ?>
                 </span>
-              </div>
-            </div>
-          <?php endforeach; ?>
+              </li>
+            <?php endforeach; ?>
+          </ul>
         <?php endif; ?>
       </div>
     </article>
 
-    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <div class="flex items-center justify-between">
-        <h2 class="text-base font-semibold">Feedback reciente</h2>
-        <span class="text-xs text-slate-500"><?= e((string) count($recentFeedback)); ?> registros</span>
-      </div>
-      <div class="mt-4 space-y-3">
+    <article class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200/70 dark:bg-slate-900 dark:ring-slate-800">
+      <header class="flex items-start justify-between gap-3">
+        <div>
+          <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Feedback reciente</h2>
+          <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">Sigue de cerca los comentarios para mantener el acompañamiento oportuno.</p>
+        </div>
+        <span class="inline-flex items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-200">
+          <?= e((string) count($recentFeedback)); ?> registros
+        </span>
+      </header>
+      <div class="mt-5">
         <?php if ($recentFeedback === []): ?>
-          <p class="text-sm text-slate-500">Aún no hay comentarios registrados.</p>
+          <p class="rounded-xl bg-slate-50 px-4 py-5 text-sm text-slate-500 dark:bg-slate-900/60 dark:text-slate-400">Aún no hay comentarios registrados.</p>
         <?php else: ?>
-          <?php foreach ($recentFeedback as $comment): ?>
-            <div class="rounded-xl border border-slate-200/70 px-3 py-3 text-sm dark:border-slate-800">
-              <div class="flex items-center justify-between gap-2">
-                <p class="font-medium text-slate-800 dark:text-slate-100">
-                  <?= e($comment['author_name']); ?>
-                </p>
-                <span class="text-[11px] uppercase tracking-wide text-slate-400">Hito: <?= e($comment['milestone_title']); ?></span>
-              </div>
-              <p class="mt-2 text-slate-600 dark:text-slate-300">"<?= e($comment['content']); ?>"</p>
-              <p class="mt-1 text-xs text-slate-400">Proyecto: <?= e($comment['project_title']); ?></p>
-            </div>
-          <?php endforeach; ?>
+          <ul class="divide-y divide-slate-100 text-sm dark:divide-slate-800">
+            <?php foreach ($recentFeedback as $comment): ?>
+              <li class="py-4 first:pt-0 last:pb-0">
+                <div class="flex flex-wrap items-center justify-between gap-2">
+                  <p class="font-medium text-slate-800 dark:text-slate-100">
+                    <?= e($comment['author_name']); ?>
+                  </p>
+                  <span class="text-[11px] font-medium uppercase tracking-wide text-slate-400">Hito: <?= e($comment['milestone_title']); ?></span>
+                </div>
+                <p class="mt-2 text-slate-600 dark:text-slate-300">"<?= e($comment['content']); ?>"</p>
+                <p class="mt-2 text-xs text-slate-400">Proyecto: <?= e($comment['project_title']); ?></p>
+              </li>
+            <?php endforeach; ?>
+          </ul>
         <?php endif; ?>
       </div>
     </article>

--- a/app/Views/dashboard/components/sections/milestones.php
+++ b/app/Views/dashboard/components/sections/milestones.php
@@ -1,34 +1,44 @@
 <?php $isMilestonesActive = ($activeTab ?? 'dashboard') === 'hitos'; ?>
-<section id="section-hitos" data-section="hitos" class="space-y-6<?= $isMilestonesActive ? '' : ' hidden'; ?>">
+<section id="section-hitos" data-section="hitos" class="space-y-8<?= $isMilestonesActive ? '' : ' hidden'; ?>">
   <?php if (!$selectedProject): ?>
-    <div class="rounded-2xl border border-slate-200 bg-white px-5 py-10 text-center text-sm text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="rounded-2xl bg-white px-6 py-12 text-center text-sm text-slate-500 shadow-sm ring-1 ring-slate-200/70 dark:bg-slate-900 dark:text-slate-400 dark:ring-slate-800">
       Selecciona un proyecto para gestionar sus hitos.
     </div>
   <?php else: ?>
-    <article class="rounded-2xl border border-slate-200 bg-white/90 p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900/80">
-      <div class="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h3 class="text-base font-semibold text-slate-800 dark:text-slate-100"><?= e($selectedProject['title']); ?></h3>
-          <p class="text-xs text-slate-500">Estudiante: <?= e($selectedProject['student_name']); ?> · Director: <?= e($selectedProject['director_name']); ?></p>
-          <p class="text-[11px] text-slate-400">Periodo: <?= e(format_dashboard_period($selectedProject['start_date'] ?? null, $selectedProject['end_date'] ?? ($selectedProject['due_date'] ?? null))); ?></p>
+    <article class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200/70 dark:bg-slate-900 dark:ring-slate-800">
+      <header class="flex flex-wrap items-start justify-between gap-4">
+        <div class="space-y-1">
+          <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Plan de hitos</h2>
+          <p class="text-sm text-slate-500 dark:text-slate-400">Organiza entregas y revisiones del proyecto seleccionado para mantener un seguimiento claro.</p>
         </div>
         <div class="flex flex-wrap items-center gap-2">
           <?php if (!empty($isDirector) && !empty($selectedProject)): ?>
             <button
               data-modal="modalMilestone"
               type="button"
-              class="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 focus:outline-none"
+              class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
             >
               <i data-lucide="plus" class="h-4 w-4"></i> Nuevo hito
             </button>
           <?php endif; ?>
-          <span class="rounded-lg px-3 py-1 text-xs font-semibold <?= e(status_badge_classes($selectedProject['status'])); ?>">Estado: <?= e(humanize_status($selectedProject['status'])); ?></span>
+          <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-200">
+            <i data-lucide="bookmark" class="h-3.5 w-3.5"></i> <?= e(humanize_status($selectedProject['status'])); ?>
+          </span>
+        </div>
+      </header>
+
+      <div class="mt-5 rounded-2xl bg-slate-50/80 p-4 text-sm leading-6 text-slate-600 ring-1 ring-slate-200/70 dark:bg-slate-900/50 dark:text-slate-300 dark:ring-slate-800/70">
+        <p class="font-medium text-slate-700 dark:text-slate-200"><?= e($selectedProject['title']); ?></p>
+        <div class="mt-2 grid gap-2 text-xs sm:grid-cols-2">
+          <span>Estudiante: <strong class="font-semibold text-slate-700 dark:text-slate-200"><?= e($selectedProject['student_name']); ?></strong></span>
+          <span>Director: <strong class="font-semibold text-slate-700 dark:text-slate-200"><?= e($selectedProject['director_name']); ?></strong></span>
+          <span class="sm:col-span-2">Periodo: <?= e(format_dashboard_period($selectedProject['start_date'] ?? null, $selectedProject['end_date'] ?? ($selectedProject['due_date'] ?? null))); ?></span>
         </div>
       </div>
 
-      <div class="mt-6 space-y-4">
+      <div class="mt-6 space-y-5">
         <?php if ($projectMilestones === []): ?>
-          <div class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900/40">Aún no hay hitos registrados.</div>
+          <div class="rounded-2xl bg-slate-50 px-5 py-8 text-center text-sm text-slate-500 shadow-inner dark:bg-slate-900/50 dark:text-slate-400">Aún no hay hitos registrados.</div>
         <?php else: ?>
           <?php foreach ($projectMilestones as $milestone): ?>
             <?php
@@ -47,25 +57,25 @@
               $canUploadDeliverable = !empty($isStudentOwner)
                   && !in_array($milestone['status'], ['en_revision', 'aprobado'], true);
             ?>
-            <article class="rounded-xl border border-slate-200/80 bg-white/80 p-4 dark:border-slate-800/70 dark:bg-slate-900/50">
-              <div class="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <h4 class="text-sm font-semibold text-slate-800 dark:text-slate-100"><?= e($milestone['title']); ?></h4>
-                  <p class="mt-1 text-xs text-slate-500"><?= e($milestone['description'] ?: 'Sin descripción.'); ?></p>
-                  <p class="mt-2 text-xs text-slate-400">Periodo: <?= e(format_dashboard_period($milestone['start_date'] ?? null, $milestone['end_date'] ?? ($milestone['due_date'] ?? null))); ?></p>
+            <article class="rounded-2xl bg-white/70 p-5 shadow-sm ring-1 ring-slate-200/70 backdrop-blur dark:bg-slate-900/60 dark:ring-slate-800/70">
+              <div class="flex flex-wrap items-start justify-between gap-4">
+                <div class="space-y-2">
+                  <h3 class="text-base font-semibold text-slate-800 dark:text-slate-100"><?= e($milestone['title']); ?></h3>
+                  <p class="text-sm text-slate-600 dark:text-slate-300"><?= e($milestone['description'] ?: 'Sin descripción.'); ?></p>
+                  <p class="text-xs text-slate-400">Periodo: <?= e(format_dashboard_period($milestone['start_date'] ?? null, $milestone['end_date'] ?? ($milestone['due_date'] ?? null))); ?></p>
                 </div>
                 <div class="flex flex-wrap items-center gap-2">
-                  <span class="rounded-lg px-2 py-1 text-[11px] font-semibold <?= e(status_badge_classes($milestone['status'])); ?>"><?= e(humanize_status($milestone['status'])); ?></span>
+                  <span class="inline-flex items-center rounded-lg px-2.5 py-1 text-[11px] font-semibold <?= e(status_badge_classes($milestone['status'])); ?>"><?= e(humanize_status($milestone['status'])); ?></span>
                   <?php if ($statusOptions !== []): ?>
-                    <form method="post" action="<?= e(url('/milestones/status')); ?>" class="flex items-center gap-1">
+                    <form method="post" action="<?= e(url('/milestones/status')); ?>" class="inline-flex items-center gap-1.5">
                       <input type="hidden" name="milestone_id" value="<?= e((string) $milestone['id']); ?>" />
                       <label class="sr-only" for="milestone-status-<?= e((string) $milestone['id']); ?>">Estado</label>
-                      <select id="milestone-status-<?= e((string) $milestone['id']); ?>" name="status" class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs outline-none dark:border-slate-700 dark:bg-slate-900">
+                      <select id="milestone-status-<?= e((string) $milestone['id']); ?>" name="status" class="rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium outline-none transition focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400">
                         <?php foreach ($statusOptions as $option): ?>
                           <option value="<?= e($option); ?>" <?= $option === ($milestone['status'] ?? '') ? 'selected' : ''; ?>><?= e(humanize_status($option)); ?></option>
                         <?php endforeach; ?>
                       </select>
-                      <button type="submit" class="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-700">
+                      <button type="submit" class="inline-flex items-center gap-1.5 rounded-lg bg-indigo-600 px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500">
                         <i data-lucide="save" class="h-3.5 w-3.5"></i>
                       </button>
                     </form>
@@ -80,13 +90,13 @@
                       data-milestone-description="<?= e($milestone['description'] ?? ''); ?>"
                       data-milestone-start="<?= e((string) ($milestone['start_date'] ?? '')); ?>"
                       data-milestone-end="<?= e((string) ($milestone['end_date'] ?? ($milestone['due_date'] ?? ''))); ?>"
-                      class="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-1 text-xs text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+                      class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-2.5 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:bg-slate-800"
                     >
                       <i data-lucide="pencil" class="h-3.5 w-3.5"></i> Editar
                     </button>
-                    <form method="post" action="<?= e(url('/milestones/delete')); ?>" class="inline-flex items-center gap-1" onsubmit="return confirm('¿Seguro que deseas eliminar este hito? Esta acción no se puede deshacer.');">
+                    <form method="post" action="<?= e(url('/milestones/delete')); ?>" class="inline-flex items-center gap-1.5" onsubmit="return confirm('¿Seguro que deseas eliminar este hito? Esta acción no se puede deshacer.');">
                       <input type="hidden" name="milestone_id" value="<?= e((string) $milestone['id']); ?>" />
-                      <button type="submit" class="inline-flex items-center gap-1 rounded-lg bg-rose-600 px-2 py-1 text-xs font-medium text-white hover:bg-rose-700">
+                      <button type="submit" class="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-rose-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500">
                         <i data-lucide="trash" class="h-3.5 w-3.5"></i> Eliminar
                       </button>
                     </form>
@@ -95,81 +105,81 @@
               </div>
 
               <div class="mt-4 grid gap-4 lg:grid-cols-2">
-                <section class="rounded-xl bg-slate-50/80 p-4 text-xs ring-1 ring-slate-200/70 dark:bg-slate-900/40 dark:ring-slate-800/70">
+                <section class="rounded-2xl bg-slate-50/80 p-4 text-xs ring-1 ring-slate-200/70 dark:bg-slate-900/40 dark:ring-slate-800/70">
                   <div class="flex items-center justify-between">
                     <p class="font-semibold text-slate-700 dark:text-slate-200">Entregables</p>
-                    <span class="rounded-lg bg-indigo-100 px-2 py-0.5 text-[11px] font-semibold text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-200">
+                    <span class="inline-flex items-center rounded-full bg-indigo-100 px-2.5 py-0.5 text-[11px] font-semibold text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-200">
                       <?= e((string) ($milestone['deliverables_count'] ?? 0)); ?>
                     </span>
                   </div>
-                  <div class="mt-3 max-h-40 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
+                  <div class="mt-3 max-h-44 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
                     <?php if ($deliverables === []): ?>
-                      <p class="text-slate-500">Sin entregas aún.</p>
+                      <p class="text-slate-500 dark:text-slate-400">Sin entregas aún.</p>
                     <?php else: ?>
                       <?php foreach ($deliverables as $deliverable): ?>
-                        <div class="rounded-lg bg-white/80 px-3 py-2 ring-1 ring-slate-200/70 transition hover:bg-white dark:bg-slate-950/30 dark:ring-slate-800/70">
+                        <div class="rounded-xl bg-white px-3 py-2 shadow-sm ring-1 ring-slate-200/70 transition hover:ring-indigo-200 dark:bg-slate-950/30 dark:ring-slate-800/70">
                           <p class="text-slate-700 dark:text-slate-200"><?= e($deliverable['original_name']); ?></p>
                           <p class="text-[11px] text-slate-400">Autor: <?= e($deliverable['author_name']); ?></p>
-                          <div class="mt-1 flex items-center justify-between text-[11px] text-slate-400">
+                          <div class="mt-2 flex flex-wrap items-center justify-between gap-2 text-[11px] text-slate-400">
                             <span><?= e($deliverable['notes'] ? 'Notas incluidas' : 'Archivo'); ?></span>
                             <?php if (!empty($deliverable['file_path'])): ?>
-                              <a class="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-0.5 text-[11px] text-indigo-600 hover:bg-indigo-50 dark:border-slate-700 dark:text-indigo-300 dark:hover:bg-indigo-900/40" href="<?= e(url('/deliverables/download?id=' . (int) $deliverable['id'])); ?>">
+                              <a class="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-0.5 text-[11px] font-medium text-indigo-600 transition hover:border-indigo-200 hover:bg-indigo-50 dark:border-slate-700 dark:text-indigo-300 dark:hover:border-indigo-400/60 dark:hover:bg-indigo-900/40" href="<?= e(url('/deliverables/download?id=' . (int) $deliverable['id'])); ?>">
                                 <i data-lucide="download" class="h-3 w-3"></i> Descargar
                               </a>
                             <?php endif; ?>
                           </div>
                           <?php if (!empty($deliverable['notes'])): ?>
-                            <p class="mt-2 rounded-lg bg-slate-100/80 px-2 py-1 text-slate-600 dark:bg-slate-800 dark:text-slate-200">"<?= e($deliverable['notes']); ?>"</p>
+                            <p class="mt-3 rounded-lg bg-slate-100 px-3 py-2 text-slate-600 dark:bg-slate-800 dark:text-slate-200">"<?= e($deliverable['notes']); ?>"</p>
                           <?php endif; ?>
                         </div>
                       <?php endforeach; ?>
                     <?php endif; ?>
                   </div>
 
-                  <div class="mt-3">
+                  <div class="mt-4">
                     <?php if ($canUploadDeliverable): ?>
-                      <form method="post" action="<?= e(url('/deliverables')); ?>" enctype="multipart/form-data" class="space-y-2">
+                      <form method="post" action="<?= e(url('/deliverables')); ?>" enctype="multipart/form-data" class="space-y-3">
                         <input type="hidden" name="milestone_id" value="<?= e((string) $milestone['id']); ?>" />
-                        <label class="block text-[11px] font-semibold uppercase text-slate-500">Subir avance</label>
-                        <input type="file" name="file" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs dark:border-slate-700 dark:bg-slate-900" />
-                        <textarea name="notes" rows="2" placeholder="Notas complementarias (opcional)" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900"></textarea>
-                        <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3 py-2 text-xs font-medium text-white hover:bg-indigo-700">
-                          <i data-lucide="upload" class="h-3.5 w-3.5"></i> Registrar avance
+                        <label class="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Registrar avance</label>
+                        <input type="file" name="file" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600 transition focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:focus:border-indigo-400" />
+                        <textarea name="notes" rows="2" placeholder="Notas complementarias (opcional)" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs outline-none transition focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:focus:border-indigo-400"></textarea>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3.5 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500">
+                          <i data-lucide="upload" class="h-3.5 w-3.5"></i> Guardar avance
                         </button>
                       </form>
                     <?php else: ?>
-                      <p class="text-[11px] text-slate-500">Solo el estudiante puede registrar avances antes de enviar a revisión o después de aprobación.</p>
+                      <p class="text-[11px] text-slate-500 dark:text-slate-400">Solo el estudiante puede registrar avances antes de enviar a revisión o después de la aprobación.</p>
                     <?php endif; ?>
                   </div>
                 </section>
 
-                <section class="rounded-xl bg-slate-50/80 p-4 text-xs ring-1 ring-slate-200/70 dark:bg-slate-900/40 dark:ring-slate-800/70">
+                <section class="rounded-2xl bg-slate-50/80 p-4 text-xs ring-1 ring-slate-200/70 dark:bg-slate-900/40 dark:ring-slate-800/70">
                   <div class="flex items-center justify-between">
                     <p class="font-semibold text-slate-700 dark:text-slate-200">Feedback</p>
-                    <span class="rounded-lg bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 dark:bg-emerald-900/60 dark:text-emerald-200">
+                    <span class="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-[11px] font-semibold text-emerald-700 dark:bg-emerald-900/60 dark:text-emerald-200">
                       <?= e((string) ($milestone['feedback_count'] ?? 0)); ?>
                     </span>
                   </div>
-                  <div class="mt-3 max-h-40 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
+                  <div class="mt-3 max-h-44 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
                     <?php if ($feedbackList === []): ?>
-                      <p class="text-slate-500">Sin comentarios aún.</p>
+                      <p class="text-slate-500 dark:text-slate-400">Sin comentarios aún.</p>
                     <?php else: ?>
                       <?php foreach ($feedbackList as $comment): ?>
-                        <div class="rounded-lg bg-white/80 px-3 py-2 ring-1 ring-slate-200/70 transition hover:bg-white dark:bg-slate-950/30 dark:ring-slate-800/70">
+                        <div class="rounded-xl bg-white px-3 py-2 shadow-sm ring-1 ring-slate-200/70 transition hover:ring-emerald-200 dark:bg-slate-950/30 dark:ring-slate-800/70">
                           <p class="font-semibold text-slate-700 dark:text-slate-200"><?= e($comment['author_name']); ?></p>
                           <p class="mt-1 text-slate-600 dark:text-slate-300">"<?= e($comment['content']); ?>"</p>
                         </div>
                       <?php endforeach; ?>
                     <?php endif; ?>
                   </div>
-                  <div class="mt-3">
-                    <form method="post" action="<?= e(url('/feedback')); ?>" class="space-y-2">
+                  <div class="mt-4">
+                    <form method="post" action="<?= e(url('/feedback')); ?>" class="space-y-3">
                       <input type="hidden" name="milestone_id" value="<?= e((string) $milestone['id']); ?>" />
                       <?php if (!empty($selectedProject)): ?>
                         <input type="hidden" name="project_id" value="<?= e((string) $selectedProject['id']); ?>">
                       <?php endif; ?>
-                      <textarea name="content" rows="3" placeholder="Escribe un comentario" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900" required></textarea>
-                      <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3 py-2 text-xs font-medium text-white hover:bg-emerald-700">
+                      <textarea name="content" rows="3" placeholder="Escribe un comentario" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs outline-none transition focus:border-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:focus:border-emerald-400" required></textarea>
+                      <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3.5 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500">
                         <i data-lucide="message-circle" class="h-3.5 w-3.5"></i> Enviar feedback
                       </button>
                     </form>

--- a/app/Views/dashboard/components/sections/progress.php
+++ b/app/Views/dashboard/components/sections/progress.php
@@ -7,23 +7,30 @@ $boardMap = [
     'aprobado' => 'Aprobado',
 ];
 ?>
-<section id="section-progreso" data-section="progreso" class="space-y-6<?= $isProgressActive ? '' : ' hidden'; ?>">
-  <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+<section id="section-progreso" data-section="progreso" class="space-y-8<?= $isProgressActive ? '' : ' hidden'; ?>">
+  <header class="flex flex-wrap items-start justify-between gap-3">
+    <div class="space-y-1">
+      <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Tablero de progreso</h2>
+      <p class="text-sm text-slate-500 dark:text-slate-400">Visualiza el flujo de trabajo por estado y detecta rápidamente los hitos que requieren atención.</p>
+    </div>
+  </header>
+
+  <div class="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-4">
     <?php foreach ($boardMap as $columnKey => $columnLabel): ?>
       <?php $items = $boardColumns[$columnKey] ?? []; ?>
-      <article class="flex h-full flex-col rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/80">
+      <article class="flex h-full flex-col rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200/70 dark:bg-slate-900 dark:ring-slate-800">
         <div class="flex items-center justify-between">
           <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-200"><?= e($columnLabel); ?></h3>
-          <span class="rounded-lg bg-slate-100 px-2 py-0.5 text-[11px] text-slate-500 dark:bg-slate-800">
+          <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-[11px] font-semibold text-slate-500 dark:bg-slate-800 dark:text-slate-300">
             <?= e((string) count($items)); ?>
           </span>
         </div>
-        <div class="mt-3 flex-1 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
+        <div class="mt-4 flex-1 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
           <?php if ($items === []): ?>
-            <p class="text-xs text-slate-500">Sin elementos.</p>
+            <p class="rounded-xl bg-slate-50 px-3 py-4 text-xs text-slate-500 dark:bg-slate-900/60 dark:text-slate-400">Sin elementos.</p>
           <?php else: ?>
             <?php foreach ($items as $item): ?>
-              <div class="rounded-xl bg-slate-50/80 p-3 text-xs ring-1 ring-slate-200/70 transition hover:bg-slate-50 dark:bg-slate-900/40 dark:ring-slate-800/70">
+              <div class="rounded-2xl bg-slate-50/80 p-3 text-xs ring-1 ring-slate-200/70 transition hover:ring-indigo-200 dark:bg-slate-900/40 dark:ring-slate-800/70">
                 <p class="font-semibold text-slate-700 dark:text-slate-100"><?= e($item['title']); ?></p>
                 <p class="mt-1 text-[11px] text-slate-500">Proyecto: <?= e($item['project_title']); ?></p>
                 <p class="mt-2 text-[11px] text-slate-400">Periodo: <?= e(format_dashboard_period($item['start_date'] ?? null, $item['end_date'] ?? ($item['due_date'] ?? null))); ?></p>

--- a/app/Views/dashboard/components/sections/projects.php
+++ b/app/Views/dashboard/components/sections/projects.php
@@ -1,101 +1,127 @@
 <?php $isProjectsActive = ($activeTab ?? 'dashboard') === 'proyectos'; ?>
-<section id="section-proyectos" data-section="proyectos" class="space-y-6<?= $isProjectsActive ? '' : ' hidden'; ?>">
-  <div class="flex flex-wrap items-center justify-end gap-3">
-    <?php if (!empty($isDirector)): ?>
-      <button data-modal="modalProject" type="button" class="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 focus:outline-none">
-        <i data-lucide="plus" class="h-4 w-4"></i> Nuevo proyecto
-      </button>
-    <?php endif; ?>
-  </div>
+<section id="section-proyectos" data-section="proyectos" class="space-y-8<?= $isProjectsActive ? '' : ' hidden'; ?>">
+  <header class="flex flex-wrap items-center justify-between gap-3">
+    <div class="max-w-xl space-y-1">
+      <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Gestión de proyectos</h2>
+      <p class="text-sm text-slate-500 dark:text-slate-400">Selecciona un proyecto para revisar sus hitos, comentarios y registrar avances.</p>
+    </div>
+    <div class="flex items-center gap-2">
+      <?php if (!empty($isDirector)): ?>
+        <button
+          data-modal="modalProject"
+          type="button"
+          class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+        >
+          <i data-lucide="plus" class="h-4 w-4"></i> Nuevo proyecto
+        </button>
+      <?php endif; ?>
+    </div>
+  </header>
 
-  <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-    <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
-      <thead class="bg-slate-50 dark:bg-slate-900/70">
-        <tr class="text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
-          <th class="px-4 py-3">Proyecto</th>
-          <th class="px-4 py-3">Estudiante</th>
-          <th class="px-4 py-3">Estado</th>
-          <th class="px-4 py-3">Periodo</th>
-          <th class="px-4 py-3 text-right">Acciones</th>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-slate-100 dark:divide-slate-800">
-        <?php if ($projects === []): ?>
-          <tr>
-            <td colspan="5" class="px-4 py-6 text-center text-sm text-slate-500">Aún no se registran proyectos.</td>
+  <div class="rounded-2xl bg-white shadow-sm ring-1 ring-slate-200/70 dark:bg-slate-900 dark:ring-slate-800">
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm leading-6 dark:divide-slate-800">
+        <thead class="bg-slate-50/80 dark:bg-slate-900/70">
+          <tr class="text-left text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
+            <th class="px-5 py-3">Proyecto</th>
+            <th class="px-5 py-3">Estudiante</th>
+            <th class="px-5 py-3">Estado</th>
+            <th class="px-5 py-3">Periodo</th>
+            <th class="px-5 py-3 text-right">Acciones</th>
           </tr>
-        <?php else: ?>
-          <?php foreach ($projects as $project): ?>
-            <?php $isProjectDirector = !empty($isDirector) && (int) ($project['director_id'] ?? 0) === $userId; ?>
-            <?php $isProjectSelected = !empty($selectedProject) && (int) ($selectedProject['id'] ?? 0) === (int) $project['id']; ?>
-            <tr class="hover:bg-slate-50/80 dark:hover:bg-slate-800/40">
-              <td class="px-4 py-3">
-                <div class="font-medium text-slate-800 dark:text-slate-100"><?= e($project['title']); ?></div>
-                <div class="text-xs text-slate-500">Director: <?= e($project['director_name']); ?></div>
-              </td>
-              <td class="px-4 py-3">
-                <div class="text-sm font-medium text-slate-700 dark:text-slate-200"><?= e($project['student_name']); ?></div>
-                <div class="text-[11px] text-slate-400"><?= e($project['student_email']); ?></div>
-              </td>
-              <td class="px-4 py-3">
-                <span class="inline-flex items-center rounded-lg px-2 py-1 text-xs font-semibold <?= e(status_badge_classes($project['status'])); ?>">
-                  <?= e(humanize_status($project['status'])); ?>
-                </span>
-              </td>
-              <td class="px-4 py-3 text-sm">
-                <?= e(format_dashboard_period($project['start_date'] ?? null, $project['end_date'] ?? ($project['due_date'] ?? null))); ?>
-              </td>
-              <td class="px-4 py-3 text-right">
-                <div class="flex flex-wrap justify-end gap-2">
-                  <?php if (!$isProjectSelected): ?>
-                    <a class="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-1 text-xs text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800" href="<?= e(url('/dashboard?tab=proyectos&project=' . (int) $project['id'])); ?>">
-                      <i data-lucide="eye" class="h-3.5 w-3.5"></i> Ver
-                    </a>
-                  <?php else: ?>
-                    <span class="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-1 text-xs text-slate-400 dark:border-slate-700 dark:text-slate-500" title="Proyecto en vista">En vista</span>
-                  <?php endif; ?>
-                  <?php if ($isProjectDirector): ?>
-                    <button
-                      type="button"
-                      data-modal="modalProjectEdit"
-                      data-project-edit
-                      data-project-id="<?= e((string) $project['id']); ?>"
-                      data-project-title="<?= e($project['title']); ?>"
-                      data-project-description="<?= e($project['description'] ?? ''); ?>"
-                      data-project-student="<?= e((string) $project['student_id']); ?>"
-                      data-project-start="<?= e((string) ($project['start_date'] ?? '')); ?>"
-                      data-project-end="<?= e((string) ($project['end_date'] ?? ($project['due_date'] ?? ''))); ?>"
-                      class="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-1 text-xs text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
-                    >
-                      <i data-lucide="pencil" class="h-3.5 w-3.5"></i> Editar
-                    </button>
-                    <form method="post" action="<?= e(url('/projects/delete')); ?>" class="inline-flex items-center gap-1" onsubmit="return confirm('¿Seguro que deseas eliminar este proyecto? Esta acción no se puede deshacer.');">
-                      <input type="hidden" name="project_id" value="<?= e((string) $project['id']); ?>" />
-                      <button type="submit" class="inline-flex items-center gap-1 rounded-lg bg-rose-600 px-2 py-1 text-xs font-medium text-white hover:bg-rose-700">
-                        <i data-lucide="trash" class="h-3.5 w-3.5"></i> Eliminar
-                      </button>
-                    </form>
-                  <?php endif; ?>
-                  <?php if ($isProjectDirector): ?>
-                    <form method="post" action="<?= e(url('/projects/status')); ?>" class="inline-flex items-center gap-1">
-                      <input type="hidden" name="project_id" value="<?= e((string) $project['id']); ?>" />
-                      <label class="sr-only" for="project-status-<?= e((string) $project['id']); ?>">Estado</label>
-                      <select id="project-status-<?= e((string) $project['id']); ?>" name="status" class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs outline-none dark:border-slate-700 dark:bg-slate-900">
-                        <?php foreach (['planificado','en_progreso','en_riesgo','completado'] as $statusOption): ?>
-                          <option value="<?= e($statusOption); ?>" <?= $statusOption === $project['status'] ? 'selected' : ''; ?>><?= e(humanize_status($statusOption)); ?></option>
-                        <?php endforeach; ?>
-                      </select>
-                      <button type="submit" class="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-700">
-                        <i data-lucide="save" class="h-3.5 w-3.5"></i>
-                      </button>
-                    </form>
-                  <?php endif; ?>
-                </div>
-              </td>
+        </thead>
+        <tbody class="divide-y divide-slate-100 bg-white/60 dark:divide-slate-800 dark:bg-transparent">
+          <?php if ($projects === []): ?>
+            <tr>
+              <td colspan="5" class="px-5 py-8 text-center text-sm text-slate-500 dark:text-slate-400">Aún no se registran proyectos.</td>
             </tr>
-          <?php endforeach; ?>
-        <?php endif; ?>
-      </tbody>
-    </table>
+          <?php else: ?>
+            <?php foreach ($projects as $project): ?>
+              <?php $isProjectDirector = !empty($isDirector) && (int) ($project['director_id'] ?? 0) === $userId; ?>
+              <?php $isProjectSelected = !empty($selectedProject) && (int) ($selectedProject['id'] ?? 0) === (int) $project['id']; ?>
+              <?php
+                $rowClasses = 'transition-colors';
+                $rowClasses .= $isProjectSelected
+                    ? ' bg-indigo-50/70 dark:bg-indigo-500/10'
+                    : ' hover:bg-slate-50/80 dark:hover:bg-slate-800/40';
+              ?>
+              <tr class="<?= e($rowClasses); ?>">
+                <td class="px-5 py-4 align-top">
+                  <div class="font-semibold text-slate-800 dark:text-slate-100"><?= e($project['title']); ?></div>
+                  <p class="mt-1 text-xs text-slate-500">Director: <?= e($project['director_name']); ?></p>
+                </td>
+                <td class="px-5 py-4 align-top">
+                  <div class="font-medium text-slate-700 dark:text-slate-200"><?= e($project['student_name']); ?></div>
+                  <p class="mt-1 text-xs text-slate-500 dark:text-slate-400"><?= e($project['student_email']); ?></p>
+                </td>
+                <td class="px-5 py-4 align-top">
+                  <span class="inline-flex items-center rounded-lg px-2.5 py-1 text-xs font-semibold <?= e(status_badge_classes($project['status'])); ?>">
+                    <?= e(humanize_status($project['status'])); ?>
+                  </span>
+                </td>
+                <td class="px-5 py-4 align-top text-sm text-slate-600 dark:text-slate-300">
+                  <?= e(format_dashboard_period($project['start_date'] ?? null, $project['end_date'] ?? ($project['due_date'] ?? null))); ?>
+                </td>
+                <td class="px-5 py-4 align-top text-right">
+                  <div class="flex flex-wrap justify-end gap-2">
+                    <?php if (!$isProjectSelected): ?>
+                      <a
+                        class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-2.5 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:bg-slate-800"
+                        href="<?= e(url('/dashboard?tab=proyectos&project=' . (int) $project['id'])); ?>"
+                      >
+                        <i data-lucide="eye" class="h-3.5 w-3.5"></i> Ver
+                      </a>
+                    <?php else: ?>
+                      <span class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-2.5 py-1.5 text-xs font-medium text-slate-400 dark:border-slate-700 dark:text-slate-500" title="Proyecto en vista">En vista</span>
+                    <?php endif; ?>
+                    <?php if ($isProjectDirector): ?>
+                      <button
+                        type="button"
+                        data-modal="modalProjectEdit"
+                        data-project-edit
+                        data-project-id="<?= e((string) $project['id']); ?>"
+                        data-project-title="<?= e($project['title']); ?>"
+                        data-project-description="<?= e($project['description'] ?? ''); ?>"
+                        data-project-student="<?= e((string) $project['student_id']); ?>"
+                        data-project-start="<?= e((string) ($project['start_date'] ?? '')); ?>"
+                        data-project-end="<?= e((string) ($project['end_date'] ?? ($project['due_date'] ?? ''))); ?>"
+                        class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-2.5 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:bg-slate-800"
+                      >
+                        <i data-lucide="pencil" class="h-3.5 w-3.5"></i> Editar
+                      </button>
+                      <form
+                        method="post"
+                        action="<?= e(url('/projects/delete')); ?>"
+                        class="inline-flex items-center gap-1.5"
+                        onsubmit="return confirm('¿Seguro que deseas eliminar este proyecto? Esta acción no se puede deshacer.');"
+                      >
+                        <input type="hidden" name="project_id" value="<?= e((string) $project['id']); ?>" />
+                        <button type="submit" class="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-rose-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500">
+                          <i data-lucide="trash" class="h-3.5 w-3.5"></i> Eliminar
+                        </button>
+                      </form>
+                    <?php endif; ?>
+                    <?php if ($isProjectDirector): ?>
+                      <form method="post" action="<?= e(url('/projects/status')); ?>" class="inline-flex items-center gap-1.5">
+                        <input type="hidden" name="project_id" value="<?= e((string) $project['id']); ?>" />
+                        <label class="sr-only" for="project-status-<?= e((string) $project['id']); ?>">Estado</label>
+                        <select id="project-status-<?= e((string) $project['id']); ?>" name="status" class="rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium outline-none transition focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-indigo-400">
+                          <?php foreach (['planificado','en_progreso','en_riesgo','completado'] as $statusOption): ?>
+                            <option value="<?= e($statusOption); ?>" <?= $statusOption === $project['status'] ? 'selected' : ''; ?>><?= e(humanize_status($statusOption)); ?></option>
+                          <?php endforeach; ?>
+                        </select>
+                        <button type="submit" class="inline-flex items-center gap-1.5 rounded-lg bg-indigo-600 px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500">
+                          <i data-lucide="save" class="h-3.5 w-3.5"></i>
+                        </button>
+                      </form>
+                    <?php endif; ?>
+                  </div>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          <?php endif; ?>
+        </tbody>
+      </table>
+    </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- refresh the dashboard overview cards and supporting panels with consistent spacing, badges, and contextual descriptions
- reorganize the projects table actions and styling for clearer hierarchy and easier status management
- polish milestones, comments, and progress boards to share unified card layouts, spacing, and empty states

## Testing
- php -l app/Views/dashboard/components/layout/main.php
- php -l app/Views/dashboard/components/sections/dashboard-overview.php
- php -l app/Views/dashboard/components/sections/projects.php
- php -l app/Views/dashboard/components/sections/milestones.php
- php -l app/Views/dashboard/components/sections/comments.php
- php -l app/Views/dashboard/components/sections/progress.php


------
https://chatgpt.com/codex/tasks/task_e_68dd5fc5ad4c832ea66ced0032438790