### PR TITLE
Fix milestone modal and refine dashboard layout

### DIFF
--- a/app/Views/dashboard/components/sections/milestones.php
+++ b/app/Views/dashboard/components/sections/milestones.php
@@ -31,12 +31,12 @@
               </span>
             </div>
           </div>
-          <div class="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+          <div class="flex flex-col items-stretch gap-3 sm:flex-row sm:flex-wrap sm:items-center">
             <span class="inline-flex items-center gap-2 rounded-full border border-indigo-200/70 bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 shadow-sm dark:border-indigo-900/60 dark:bg-indigo-950/50 dark:text-indigo-200">
               <i data-lucide="circle-check" class="h-3.5 w-3.5"></i>
               <?= e((string) $milestonesCount); ?> hitos
             </span>
-            <div class="flex flex-wrap items-center justify-end gap-2">
+            <div class="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
               <?php if (!empty($isDirector) && !empty($selectedProject)): ?>
                 <button
                   data-modal="modalMilestone"
@@ -86,7 +86,7 @@
                   <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                     <div class="space-y-3"><h4 class="text-base font-semibold text-slate-800 dark:text-slate-100"><?= e($milestone['title']); ?></h4>
                       <p class="text-sm text-slate-500 dark:text-slate-300"><?= e($milestone['description'] ?: 'Sin descripcion.'); ?></p>
-                      <div class="flex flex-wrap items-center gap-2 text-[11px] text-slate-400">
+                      <div class="flex flex-wrap items-center gap-2 text-[11px] text-slate-400 sm:gap-3">
                         <span class="inline-flex items-center gap-1 rounded-full border border-slate-200/70 bg-white/70 px-2.5 py-1 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/70">
                           <i data-lucide="calendar" class="h-3 w-3 text-indigo-400"></i>
                           <?= e(format_dashboard_period($milestone['start_date'] ?? null, $milestone['end_date'] ?? ($milestone['due_date'] ?? null))); ?>
@@ -97,13 +97,13 @@
                         </span>
                       </div>
                     </div>
-                    <div class="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
+                    <div class="flex flex-col items-start gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-3">
                       <span class="<?= e($milestoneStatusClasses); ?>">
                         <i data-lucide="circle-dot" class="h-3 w-3"></i>
                         <?= e(humanize_status($milestone['status'])); ?>
                       </span>
                       <?php if ($statusOptions !== []): ?>
-                        <form method="post" action="<?= e(url('/milestones/status')); ?>" class="flex items-center gap-2">
+                        <form method="post" action="<?= e(url('/milestones/status')); ?>" class="flex items-center gap-2 sm:gap-3">
                           <input type="hidden" name="milestone_id" value="<?= e((string) $milestone['id']); ?>" />
                           <label class="sr-only" for="milestone-status-<?= e((string) $milestone['id']); ?>">Estado</label>
                           <select id="milestone-status-<?= e((string) $milestone['id']); ?>" name="status" class="rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 shadow-sm transition hover:border-indigo-200 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:border-indigo-500">
@@ -111,13 +111,18 @@
                               <option value="<?= e($option); ?>" <?= $option === ($milestone['status'] ?? '') ? 'selected' : ''; ?>><?= e(humanize_status($option)); ?></option>
                             <?php endforeach; ?>
                           </select>
+                          <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-xl border border-indigo-200/70 bg-indigo-50 px-3 py-1.5 text-xs font-semibold text-indigo-700 shadow-sm transition hover:-translate-y-0.5 hover:bg-indigo-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 dark:border-indigo-900/60 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50">
+                            <i data-lucide="save" class="h-3.5 w-3.5"></i>
+                            <span class="sr-only">Guardar estado</span>
+                          </button>
                         </form>
                       <?php endif; ?>
                       <?php if ($isDirectorOwner): ?>
-                        <div class="flex items-center gap-2">
+                        <div class="flex flex-wrap items-center gap-2 sm:gap-3">
                           <button
                             type="button"
-                            data-modal="modalMilestone"
+                            data-modal="modalMilestoneEdit"
+                            data-milestone-edit
                             data-milestone-id="<?= e((string) $milestone['id']); ?>"
                             data-milestone-title="<?= e($milestone['title']); ?>"
                             data-milestone-description="<?= e((string) ($milestone['description'] ?? '')); ?>"

--- a/app/Views/dashboard/components/sections/projects.php
+++ b/app/Views/dashboard/components/sections/projects.php
@@ -34,18 +34,19 @@ $selectedProjectTitle = $selectedProject['title'] ?? null;
         </div>
       </header>
 
-      <div class="overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 shadow-md shadow-slate-200/60 dark:border-slate-800/70 dark:bg-slate-900/70">
-        <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
-          <thead class="bg-gradient-to-r from-indigo-50 to-transparent text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:from-slate-900/60 dark:text-slate-300">
-            <tr>
-              <th scope="col" class="px-4 py-3">Proyecto</th>
-              <th scope="col" class="px-4 py-3">Estudiante</th>
-              <th scope="col" class="px-4 py-3">Estado</th>
-              <th scope="col" class="px-4 py-3">Periodo</th>
-              <th scope="col" class="px-4 py-3 text-right">Acciones</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-slate-100/70 dark:divide-slate-800/70">
+      <div class="rounded-2xl border border-slate-200/70 bg-white/80 shadow-md shadow-slate-200/60 dark:border-slate-800/70 dark:bg-slate-900/70">
+        <div class="overflow-x-auto rounded-2xl">
+          <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
+            <thead class="bg-gradient-to-r from-indigo-50 to-transparent text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:from-slate-900/60 dark:text-slate-300">
+              <tr>
+                <th scope="col" class="px-4 py-3">Proyecto</th>
+                <th scope="col" class="px-4 py-3">Estudiante</th>
+                <th scope="col" class="px-4 py-3">Estado</th>
+                <th scope="col" class="px-4 py-3">Periodo</th>
+                <th scope="col" class="px-4 py-3 text-right">Acciones</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-100/70 dark:divide-slate-800/70">
             <?php if ($projectsList === []): ?>
               <tr>
                 <td colspan="5" class="px-4 py-8 text-center text-sm text-slate-500">
@@ -88,8 +89,8 @@ $selectedProjectTitle = $selectedProject['title'] ?? null;
                     <?= e(format_dashboard_period($project['start_date'] ?? null, $project['end_date'] ?? ($project['due_date'] ?? null))); ?>
                   </td>
                   <td class="px-4 py-4 align-top text-right">
-                    <div class="flex flex-col items-end gap-2 text-xs sm:flex-row sm:justify-end sm:gap-3">
-                      <div class="flex flex-wrap items-center justify-end gap-2">
+                    <div class="flex flex-col items-end gap-2 text-xs sm:flex-row sm:items-center sm:justify-end sm:gap-3">
+                      <div class="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
                         <?php if (!$isProjectSelected): ?>
                           <a class="inline-flex items-center gap-2 rounded-xl border border-slate-200/70 bg-white/70 px-3 py-1.5 text-xs font-semibold text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-indigo-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200"
                              href="<?= e(url('/dashboard?tab=proyectos&project=' . (int) $project['id'])); ?>">
@@ -126,7 +127,7 @@ $selectedProjectTitle = $selectedProject['title'] ?? null;
                       </div>
 
                       <?php if ($isProjectDirector): ?>
-                        <form method="post" action="<?= e(url('/projects/status')); ?>" class="inline-flex items-center gap-2">
+                        <form method="post" action="<?= e(url('/projects/status')); ?>" class="inline-flex items-center gap-2 sm:gap-3">
                           <input type="hidden" name="project_id" value="<?= e((string) $project['id']); ?>" />
                           <label class="sr-only" for="project-status-<?= e((string) $project['id']); ?>">Estado</label>
                           <select id="project-status-<?= e((string) $project['id']); ?>" name="status" class="rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 shadow-sm transition hover:border-indigo-200 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:border-indigo-500">
@@ -144,8 +145,9 @@ $selectedProjectTitle = $selectedProject['title'] ?? null;
                 </tr>
               <?php endforeach; ?>
             <?php endif; ?>
-          </tbody>
-        </table>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </article>


### PR DESCRIPTION
## Summary
- point the milestone edit button to the dedicated edit modal and expose the expected data attribute for script bindings
- add an accessible submit control to the milestone status form and refine spacing/alignment for chips, selects and buttons
- wrap the projects table in a horizontal scroll container while keeping styling, and align action controls for consistency

## Testing
- php -l app/Views/dashboard/components/sections/milestones.php
- php -l app/Views/dashboard/components/sections/projects.php

------
https://chatgpt.com/codex/tasks/task_e_68dd8792cad4832e8a808a2c69eccbbb