### PR TITLE
Filtrar tablero Kanban por proyecto seleccionado

### DIFF
--- a/app/Controllers/DashboardController.php
+++ b/app/Controllers/DashboardController.php
@@ -75,7 +75,7 @@ class DashboardController extends Controller
         $stats = $this->projects->statsForUser($user);
         $upcomingMilestones = $this->projects->upcomingMilestones($user);
         $recentFeedback = $this->feedback->recentForUser($user);
-        $boardColumns = $this->projects->boardColumns($user);
+        $boardColumns = $this->projects->boardColumns($user, $selectedProjectId > 0 ? $selectedProjectId : null);
 
         $students = [];
         if (($user['role'] ?? '') === 'director') {

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -336,7 +336,7 @@ class Project
         return $statement->fetchAll(PDO::FETCH_ASSOC) ?: [];
     }
 
-    public function boardColumns(array $user): array
+    public function boardColumns(array $user, ?int $projectId = null): array
     {
         $role = $user['role'] ?? 'estudiante';
         $userId = (int) ($user['id'] ?? 0);
@@ -354,11 +354,19 @@ class Project
         FROM milestones m
         INNER JOIN projects p ON p.id = m.project_id
         WHERE $column = :id
-        ORDER BY m.status, COALESCE(m.position, m.created_at)
         SQL;
+
+        if ($projectId !== null && $projectId > 0) {
+            $sql .= '\n        AND m.project_id = :project_id';
+        }
+
+        $sql .= '\n        ORDER BY m.status, COALESCE(m.position, m.created_at)';
 
         $statement = $this->db->prepare($sql);
         $statement->bindValue(':id', $userId, PDO::PARAM_INT);
+        if ($projectId !== null && $projectId > 0) {
+            $statement->bindValue(':project_id', $projectId, PDO::PARAM_INT);
+        }
         $statement->execute();
 
         $milestones = $statement->fetchAll(PDO::FETCH_ASSOC) ?: [];


### PR DESCRIPTION
## Summary
- Filtrar las columnas del tablero Kanban por el proyecto actualmente seleccionado en el dashboard
- Ajustar el controlador para pasar el identificador del proyecto seleccionado al generar el tablero

## Testing
- php -l app/Controllers/DashboardController.php
- php -l app/Models/Project.php

------
https://chatgpt.com/codex/tasks/task_e_68ddab52e540832e92f8e6017efff502