### PR TITLE
Allow filtering board columns by selected project

### DIFF
--- a/app/Controllers/DashboardController.php
+++ b/app/Controllers/DashboardController.php
@@ -75,7 +75,7 @@ class DashboardController extends Controller
         $stats = $this->projects->statsForUser($user);
         $upcomingMilestones = $this->projects->upcomingMilestones($user);
         $recentFeedback = $this->feedback->recentForUser($user);
-        $boardColumns = $this->projects->boardColumns($user);
+        $boardColumns = $this->projects->boardColumns($user, $selectedProjectId ?: null);
 
         $students = [];
         if (($user['role'] ?? '') === 'director') {

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -336,7 +336,7 @@ class Project
         return $statement->fetchAll(PDO::FETCH_ASSOC) ?: [];
     }
 
-    public function boardColumns(array $user): array
+    public function boardColumns(array $user, ?int $projectId = null): array
     {
         $role = $user['role'] ?? 'estudiante';
         $userId = (int) ($user['id'] ?? 0);
@@ -354,11 +354,19 @@ class Project
         FROM milestones m
         INNER JOIN projects p ON p.id = m.project_id
         WHERE $column = :id
-        ORDER BY m.status, COALESCE(m.position, m.created_at)
         SQL;
+
+        if ($projectId !== null) {
+            $sql .= " AND m.project_id = :projectId";
+        }
+
+        $sql .= " ORDER BY m.status, COALESCE(m.position, m.created_at)";
 
         $statement = $this->db->prepare($sql);
         $statement->bindValue(':id', $userId, PDO::PARAM_INT);
+        if ($projectId !== null) {
+            $statement->bindValue(':projectId', $projectId, PDO::PARAM_INT);
+        }
         $statement->execute();
 
         $milestones = $statement->fetchAll(PDO::FETCH_ASSOC) ?: [];


### PR DESCRIPTION
## Summary
- pass the selected project id to the board columns loader in the dashboard controller
- allow filtering milestones by project id inside `Project::boardColumns`

## Testing
- not run (environment only provides CLI access)

------
https://chatgpt.com/codex/tasks/task_e_68ddbdddb5d4832e9c291962534df90b