### PR TITLE
Improve dashboard module alignment and sizing

### DIFF
--- a/app/Views/dashboard/components/sections/dashboard-overview.php
+++ b/app/Views/dashboard/components/sections/dashboard-overview.php
@@ -43,10 +43,10 @@ $recentFeedbackCount = count($recentFeedback ?? []);
         </span>
       </header>
 
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <div class="grid grid-cols-1 items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <?php foreach ($statCards as $card): ?>
-          <article class="rounded-2xl border border-slate-200/60 bg-white/80 p-4 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
-            <div class="flex items-center justify-between">
+          <article class="flex h-full flex-col justify-between rounded-2xl border border-slate-200/60 bg-white/80 p-4 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
+            <div class="flex items-center justify-between gap-3">
               <p class="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-300"><?= e($card['label']); ?></p>
               <i data-lucide="<?= e($card['icon']); ?>" class="h-5 w-5 <?= e($card['accent']); ?>"></i>
             </div>
@@ -55,8 +55,8 @@ $recentFeedbackCount = count($recentFeedback ?? []);
         <?php endforeach; ?>
       </div>
 
-      <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
-        <article class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
+      <div class="grid grid-cols-1 items-stretch gap-4 xl:grid-cols-2">
+        <article class="flex h-full flex-col rounded-2xl border border-slate-200/60 bg-white/80 p-5 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
           <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div class="space-y-1">
               <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Proximos hitos</h2>
@@ -67,7 +67,7 @@ $recentFeedbackCount = count($recentFeedback ?? []);
               <?= e((string) $upcomingCount); ?> pendientes
             </span>
           </div>
-          <div class="mt-4 space-y-3">
+          <div class="mt-4 flex-1 space-y-3">
             <?php if ($upcomingMilestones === []): ?>
               <p class="rounded-2xl border border-dashed border-slate-300/80 bg-slate-50/70 px-4 py-6 text-center text-sm text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/50">Sin hitos programados en los proximos dias.</p>
             <?php else: ?>
@@ -89,7 +89,7 @@ $recentFeedbackCount = count($recentFeedback ?? []);
           </div>
         </article>
 
-        <article class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
+        <article class="flex h-full flex-col rounded-2xl border border-slate-200/60 bg-white/80 p-5 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
           <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div class="space-y-1">
               <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Feedback reciente</h2>
@@ -100,7 +100,7 @@ $recentFeedbackCount = count($recentFeedback ?? []);
               <?= e((string) $recentFeedbackCount); ?> registros
             </span>
           </div>
-          <div class="mt-4 space-y-3">
+          <div class="mt-4 flex-1 space-y-3">
             <?php if ($recentFeedback === []): ?>
               <p class="rounded-2xl border border-dashed border-slate-300/80 bg-slate-50/70 px-4 py-6 text-center text-sm text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/50">Aun no hay comentarios registrados.</p>
             <?php else: ?>

--- a/app/Views/dashboard/components/sections/milestones.php
+++ b/app/Views/dashboard/components/sections/milestones.php
@@ -143,8 +143,8 @@
                     </div>
                   </div>
 
-                  <div class="grid gap-4 lg:grid-cols-2">
-                    <section class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 text-xs shadow-inner shadow-slate-200/40 dark:border-slate-800/60 dark:bg-slate-900/60">
+                  <div class="grid items-stretch gap-4 lg:grid-cols-2">
+                    <section class="flex h-full flex-col rounded-2xl border border-slate-200/60 bg-white/80 p-5 text-xs shadow-inner shadow-slate-200/40 dark:border-slate-800/60 dark:bg-slate-900/60">
                       <div class="flex items-center justify-between">
                         <p class="font-semibold text-slate-700 dark:text-slate-200">Entregables</p>
                         <span class="inline-flex items-center gap-1 rounded-full border border-indigo-200/70 bg-indigo-50 px-2.5 py-0.5 text-[11px] font-semibold text-indigo-700 shadow-sm dark:border-indigo-900/60 dark:bg-indigo-950/40 dark:text-indigo-200">
@@ -152,7 +152,7 @@
                           <?= e((string) $milestoneDeliverablesCount); ?>
                         </span>
                       </div>
-                      <div class="mt-3 max-h-48 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
+                      <div class="mt-3 max-h-48 flex-1 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
                         <?php if ($deliverables === []): ?>
                           <p class="rounded-xl border border-dashed border-slate-300/80 bg-slate-50/70 px-3 py-2 text-center text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/50">Sin entregas aun.</p>
                         <?php else: ?>
@@ -195,7 +195,7 @@
                       </div>
                     </section>
 
-                    <section class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 text-xs shadow-inner shadow-slate-200/40 dark:border-slate-800/60 dark:bg-slate-900/60">
+                    <section class="flex h-full flex-col rounded-2xl border border-slate-200/60 bg-white/80 p-5 text-xs shadow-inner shadow-slate-200/40 dark:border-slate-800/60 dark:bg-slate-900/60">
                       <div class="flex items-center justify-between">
                         <p class="font-semibold text-slate-700 dark:text-slate-200">Feedback</p>
                         <span class="inline-flex items-center gap-1 rounded-full border border-emerald-200/70 bg-emerald-50 px-2.5 py-0.5 text-[11px] font-semibold text-emerald-700 shadow-sm dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-200">
@@ -203,7 +203,7 @@
                           <?= e((string) ($milestone['feedback_count'] ?? 0)); ?>
                         </span>
                       </div>
-                      <div class="mt-3 max-h-48 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
+                      <div class="mt-3 max-h-48 flex-1 space-y-3 overflow-y-auto pr-1 scrollbar-thin">
                         <?php if ($feedbackList === []): ?>
                           <p class="rounded-xl border border-dashed border-slate-300/80 bg-slate-50/70 px-3 py-2 text-center text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/50">Sin comentarios aun.</p>
                         <?php else: ?>

--- a/app/Views/dashboard/components/sections/progress.php
+++ b/app/Views/dashboard/components/sections/progress.php
@@ -26,7 +26,7 @@ foreach ($boardMap as $columnKey => $_columnLabel) {
         </span>
       </header>
 
-      <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div class="grid grid-cols-1 items-stretch gap-4 md:grid-cols-2 xl:grid-cols-4">
         <?php foreach ($boardMap as $columnKey => $columnLabel): ?>
           <?php $items = $boardColumnsList[$columnKey] ?? []; ?>
           <article class="flex h-full flex-col rounded-2xl border border-slate-200/60 bg-white/80 p-5 text-xs shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">


### PR DESCRIPTION
## Summary
- make overview statistic cards stretch evenly and maintain consistent height
- ensure upcoming milestones and feedback panels expand to fill grid rows responsively
- align milestone detail columns by stretching deliverables and feedback containers and adjusting the kanban grid layout

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ddcd403400832ea1d7c7e0a1112677