### PR TITLE
Auto-dismiss alerts and add register scroll hint

### DIFF
--- a/app/Views/auth/index.php
+++ b/app/Views/auth/index.php
@@ -115,7 +115,10 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
         <?php endif; ?>
 
         <?php if ($success): ?>
-          <div class="mb-5 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm text-emerald-700">
+          <div
+            class="mb-5 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm text-emerald-700"
+            data-auto-dismiss="6000"
+          >
             <?= e($success); ?>
           </div>
         <?php endif; ?>
@@ -136,7 +139,10 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
             <div class="rounded-2xl bg-white p-4 sm:p-6 lg:p-8 shadow-sm ring-1 ring-slate-200">
               <form class="space-y-4 sm:space-y-5" method="post" action="<?= e(url('/login')); ?>">
                 <?php if ($hasError('login_general')): ?>
-                  <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+                  <div
+                    class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600"
+                    data-auto-dismiss="7000"
+                  >
                     <?= e($errorText('login_general')); ?>
                   </div>
                 <?php endif; ?>
@@ -184,7 +190,10 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
             <div class="rounded-2xl bg-white p-4 sm:p-6 lg:p-8 shadow-sm ring-1 ring-slate-200">
               <form class="space-y-4 sm:space-y-5" method="post" action="<?= e(url('/register')); ?>">
                 <?php if ($hasError('register_general')): ?>
-                  <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+                  <div
+                    class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600"
+                    data-auto-dismiss="7000"
+                  >
                     <?= e($errorText('register_general')); ?>
                   </div>
                 <?php endif; ?>
@@ -267,6 +276,18 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
               </form>
             </div>
           </section>
+
+          <div
+            id="register-scroll-indicator"
+            class="pointer-events-none absolute inset-x-0 bottom-3 hidden sm:flex flex-col items-center gap-1 text-[10px] font-medium text-slate-500 transition-opacity duration-300 ease-out opacity-0"
+          >
+            <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/80 shadow-sm ring-1 ring-slate-200/70">
+              <svg class="h-3.5 w-3.5 text-[#1869db]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M6 9l6 6 6-6"></path>
+              </svg>
+            </span>
+            <span class="rounded-full bg-white/80 px-2.5 py-0.5 shadow-sm ring-1 ring-slate-200/70">Despl&aacute;zate para ver m&aacute;s</span>
+          </div>
         </div>
       </div>
     </main>
@@ -276,19 +297,75 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
     const tabButtons = Array.from(document.querySelectorAll('#auth-tabs .tab'));
     const panels = Array.from(document.querySelectorAll('.panel'));
     const authTabs = document.getElementById('auth-tabs');
+    const panelContainer = document.getElementById('panel-container');
+    const scrollIndicator = document.getElementById('register-scroll-indicator');
+
+    function setupAutoDismissAlerts(root = document) {
+      const alerts = Array.from(root.querySelectorAll('[data-auto-dismiss]'));
+      alerts.forEach((alert) => {
+        if (alert.dataset.autoDismissBound === 'true') return;
+        alert.dataset.autoDismissBound = 'true';
+        const delay = Number(alert.dataset.autoDismiss) || 5000;
+        window.setTimeout(() => {
+          alert.classList.add('transition-opacity', 'duration-500', 'ease-out');
+          alert.style.opacity = '0';
+          alert.addEventListener(
+            'transitionend',
+            () => {
+              alert.remove();
+              const activePanel = document.querySelector('.panel:not(.hidden)');
+              if (activePanel) {
+                setContainerHeightFor(activePanel);
+              }
+              updateScrollIndicator();
+            },
+            { once: true }
+          );
+        }, delay);
+      });
+    }
+
+    setupAutoDismissAlerts();
+
+    function updateScrollIndicator() {
+      if (!panelContainer || !scrollIndicator) return;
+      const registerPanel = document.getElementById('panel-register');
+      if (!registerPanel) return;
+
+      const hideOnMobile = window.matchMedia('(max-width: 639px)').matches;
+      if (hideOnMobile) {
+        scrollIndicator.classList.add('opacity-0');
+        scrollIndicator.classList.remove('opacity-100');
+        return;
+      }
+
+      const threshold = 8;
+      const isRegisterActive = !registerPanel.classList.contains('hidden');
+      const hasOverflow = panelContainer.scrollHeight - panelContainer.clientHeight > threshold;
+      const notAtBottom = panelContainer.scrollTop + panelContainer.clientHeight < panelContainer.scrollHeight - threshold;
+
+      if (isRegisterActive && hasOverflow && notAtBottom) {
+        scrollIndicator.classList.add('opacity-100');
+        scrollIndicator.classList.remove('opacity-0');
+      } else {
+        scrollIndicator.classList.add('opacity-0');
+        scrollIndicator.classList.remove('opacity-100');
+      }
+    }
 
     function setContainerHeightFor(panel) {
-      const container = document.getElementById('panel-container');
-      if (!panel || !container) return;
+      if (!panel || !panelContainer) return;
       const clone = panel.cloneNode(true);
       clone.style.height = 'auto';
       clone.classList.remove('hidden');
       clone.style.position = 'absolute';
       clone.style.visibility = 'hidden';
-      container.appendChild(clone);
+      clone.style.pointerEvents = 'none';
+      panelContainer.appendChild(clone);
       const height = clone.getBoundingClientRect().height;
-      container.style.height = height + 'px';
-      container.removeChild(clone);
+      panelContainer.style.height = height + 'px';
+      panelContainer.removeChild(clone);
+      window.requestAnimationFrame(updateScrollIndicator);
     }
 
     function activateTab(button) {
@@ -315,6 +392,10 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
       requestAnimationFrame(() => nextPanel.classList.add('fade-enter-active'));
       setTimeout(() => nextPanel.classList.remove('fade-enter', 'fade-enter-active'), 200);
       setContainerHeightFor(nextPanel);
+      if (panelContainer) {
+        panelContainer.scrollTop = 0;
+      }
+      updateScrollIndicator();
     }
 
     window.addEventListener('load', () => {
@@ -326,6 +407,10 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
     });
 
     tabButtons.forEach((btn) => btn.addEventListener('click', () => activateTab(btn)));
+
+    panelContainer?.addEventListener('scroll', () => {
+      updateScrollIndicator();
+    });
 
     authTabs.addEventListener('keydown', (event) => {
       if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
@@ -385,6 +470,7 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
         setTimeout(() => {
           const activePanel = document.querySelector('.panel:not(.hidden)');
           setContainerHeightFor(activePanel);
+          updateScrollIndicator();
         }, 150);
       }
     }
@@ -400,6 +486,7 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
       resizeTimer = setTimeout(() => {
         const active = document.querySelector('.panel:not(.hidden)');
         if (active) setContainerHeightFor(active);
+        updateScrollIndicator();
       }, 150);
     });
 

--- a/app/Views/auth/password_change.php
+++ b/app/Views/auth/password_change.php
@@ -38,13 +38,19 @@ $tokenError = $tokenError ?? null;
       </div>
 
       <?php if ($status): ?>
-        <div class="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+        <div
+          class="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
+          data-auto-dismiss="6000"
+        >
           <?= e($status); ?>
         </div>
       <?php endif; ?>
 
       <?php if ($tokenError): ?>
-        <div class="mb-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+        <div
+          class="mb-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600"
+          data-auto-dismiss="7000"
+        >
           <?= e($tokenError); ?>
         </div>
       <?php endif; ?>
@@ -125,5 +131,26 @@ $tokenError = $tokenError ?? null;
       </div>
     </div>
   </div>
+  <script>
+    (function () {
+      const alerts = Array.from(document.querySelectorAll('[data-auto-dismiss]'));
+      alerts.forEach((alert) => {
+        if (alert.dataset.autoDismissBound === 'true') return;
+        alert.dataset.autoDismissBound = 'true';
+        const delay = Number(alert.dataset.autoDismiss) || 5000;
+        window.setTimeout(() => {
+          alert.classList.add('transition-opacity', 'duration-500', 'ease-out');
+          alert.style.opacity = '0';
+          alert.addEventListener(
+            'transitionend',
+            () => {
+              alert.remove();
+            },
+            { once: true }
+          );
+        }, delay);
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/app/Views/dashboard/components/layout/scripts.php
+++ b/app/Views/dashboard/components/layout/scripts.php
@@ -11,6 +11,30 @@
     const sidebarBackdrop = document.getElementById('sidebarBackdrop');
     const btnSidebar = document.getElementById('btnSidebar');
     const body = document.body;
+
+    function setupAutoDismissAlerts(root = document) {
+      const alerts = Array.from(root.querySelectorAll('[data-auto-dismiss]'));
+      alerts.forEach(alert => {
+        if (alert.dataset.autoDismissBound === 'true') {
+          return;
+        }
+        alert.dataset.autoDismissBound = 'true';
+        const delay = Number(alert.dataset.autoDismiss) || 5000;
+        window.setTimeout(() => {
+          alert.classList.add('transition-opacity', 'duration-500', 'ease-out');
+          alert.style.opacity = '0';
+          alert.addEventListener(
+            'transitionend',
+            () => {
+              alert.remove();
+            },
+            { once: true }
+          );
+        }, delay);
+      });
+    }
+
+    setupAutoDismissAlerts();
     const mediaQueryDesktop = window.matchMedia('(min-width: 768px)');
     const pageTitle = document.getElementById('pageTitle');
     const pageSubtitle = document.getElementById('pageSubtitle');

--- a/app/Views/dashboard/components/shared/alerts.php
+++ b/app/Views/dashboard/components/shared/alerts.php
@@ -1,5 +1,8 @@
 <?php if ($success): ?>
-  <div class="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-100">
+  <div
+    class="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-100"
+    data-auto-dismiss="6000"
+  >
     <?= e($success); ?>
   </div>
 <?php endif; ?>
@@ -7,7 +10,10 @@
 <?php if ($errors): ?>
   <div class="mb-4 space-y-2">
     <?php foreach ($errors as $error): ?>
-      <div class="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-800 dark:bg-rose-900/40 dark:text-rose-100">
+      <div
+        class="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-800 dark:bg-rose-900/40 dark:text-rose-100"
+        data-auto-dismiss="7000"
+      >
         <?= e($error); ?>
       </div>
     <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- add auto-dismiss attributes to alert components and wire them to new JS helpers in the dashboard and auth flows
- enhance the auth screens with reusable auto-dismiss behavior and a scroll hint indicator for the register form, now more discreto y oculto en móviles cuando no aplica

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df790b6ef4832eb149f1c16fcc7849