### PR TITLE
Prevent project creation with past start dates

### DIFF
--- a/app/Controllers/ProjectsController.php
+++ b/app/Controllers/ProjectsController.php
@@ -101,6 +101,13 @@ class ProjectsController extends Controller
             $errors[] = 'La fecha de finalizacion debe ser posterior o igual a la fecha de inicio.';
         }
 
+        if ($startDateObject) {
+            $today = new DateTimeImmutable('today');
+            if ($startDateObject < $today) {
+                $errors[] = 'La fecha de inicio debe ser igual o posterior a hoy.';
+            }
+        }
+
         if ($endDateObject) {
             $today = new DateTimeImmutable('today');
             if ($endDateObject < $today) {


### PR DESCRIPTION
## Summary
- add validation to ensure project start date is not earlier than today

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dffcbf7fe8832e98d404a22ac39aa8