### PR TITLE
Implement dashboard notifications system

### DIFF
--- a/app/Controllers/DashboardController.php
+++ b/app/Controllers/DashboardController.php
@@ -7,6 +7,7 @@ use App\Helpers\Session;
 use App\Models\Deliverable;
 use App\Models\Feedback;
 use App\Models\Milestone;
+use App\Models\Notification;
 use App\Models\Project;
 use App\Models\User;
 
@@ -17,6 +18,7 @@ class DashboardController extends Controller
     private Deliverable $deliverables;
     private Feedback $feedback;
     private User $users;
+    private Notification $notifications;
 
     public function __construct()
     {
@@ -27,6 +29,7 @@ class DashboardController extends Controller
         $this->deliverables = new Deliverable();
         $this->feedback = new Feedback();
         $this->users = new User();
+        $this->notifications = new Notification();
     }
 
     public function index(): void
@@ -77,6 +80,9 @@ class DashboardController extends Controller
         $recentFeedback = $this->feedback->recentForUser($user);
         $boardColumns = $this->projects->boardColumns($user, $selectedProjectId ?: null);
 
+        $notifications = $this->notifications->allForUser((int) ($user['id'] ?? 0), 15);
+        $unreadNotifications = $this->notifications->countUnreadForUser((int) ($user['id'] ?? 0));
+
         $students = [];
         if (($user['role'] ?? '') === 'director') {
             $students = $this->users->allByRole('estudiante');
@@ -99,6 +105,8 @@ class DashboardController extends Controller
             'boardColumns' => $boardColumns,
             'students' => $students,
             'modalTarget' => $modalTarget,
+            'notifications' => $notifications,
+            'unreadNotificationCount' => $unreadNotifications,
         ]);
     }
 

--- a/app/Controllers/NotificationsController.php
+++ b/app/Controllers/NotificationsController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Core\Controller;
+use App\Helpers\Session;
+use App\Models\Notification;
+
+class NotificationsController extends Controller
+{
+    private Notification $notifications;
+
+    public function __construct()
+    {
+        parent::__construct();
+        Session::start();
+        $this->notifications = new Notification();
+    }
+
+    public function index(): void
+    {
+        $user = Session::user();
+        if (!$user) {
+            $this->json(['error' => 'No autorizado'], 401);
+            return;
+        }
+
+        $userId = (int) ($user['id'] ?? 0);
+        $limit = isset($_GET['limit']) ? (int) $_GET['limit'] : 15;
+        $limit = max(1, min($limit, 50));
+
+        $items = $this->notifications->allForUser($userId, $limit, false);
+        $unread = $this->notifications->countUnreadForUser($userId);
+
+        $this->json([
+            'notifications' => $items,
+            'unread_count' => $unread,
+        ]);
+    }
+
+    public function markAsRead(): void
+    {
+        $user = Session::user();
+        if (!$user) {
+            $this->json(['error' => 'No autorizado'], 401);
+            return;
+        }
+
+        $payload = $this->resolvePayload();
+        $userId = (int) ($user['id'] ?? 0);
+
+        if (!empty($payload['mark_all'])) {
+            $this->notifications->markAllForUser($userId);
+        } else {
+            $ids = [];
+            if (isset($payload['ids']) && is_array($payload['ids'])) {
+                $ids = $payload['ids'];
+            } elseif (isset($payload['notification_id'])) {
+                $ids = [$payload['notification_id']];
+            }
+
+            if ($ids !== []) {
+                $this->notifications->markManyAsRead($ids, $userId);
+            }
+        }
+
+        $this->json([
+            'status' => 'ok',
+            'unread_count' => $this->notifications->countUnreadForUser($userId),
+        ]);
+    }
+
+    private function json(array $data, int $status = 200): void
+    {
+        http_response_code($status);
+        header('Content-Type: application/json; charset=UTF-8');
+        echo json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function resolvePayload(): array
+    {
+        $contentType = $_SERVER['CONTENT_TYPE'] ?? $_SERVER['HTTP_CONTENT_TYPE'] ?? '';
+        if ($contentType !== '' && stripos($contentType, 'application/json') !== false) {
+            $raw = file_get_contents('php://input');
+            if ($raw !== false && $raw !== '') {
+                $decoded = json_decode($raw, true);
+                if (is_array($decoded)) {
+                    return $decoded;
+                }
+            }
+
+            return [];
+        }
+
+        return $_POST ?? [];
+    }
+}

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace App\Models;
+
+use App\Core\Database;
+use DateTimeImmutable;
+use PDO;
+use RuntimeException;
+
+class Notification
+{
+    private PDO $db;
+
+    public function __construct()
+    {
+        $this->db = Database::connection();
+        $this->ensureTable();
+    }
+
+    private function ensureTable(): void
+    {
+        $driver = $this->db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'mysql') {
+            $sql = <<<SQL
+            CREATE TABLE IF NOT EXISTS notifications (
+                id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                user_id INT UNSIGNED NOT NULL,
+                type VARCHAR(100) NULL,
+                title VARCHAR(200) NOT NULL,
+                body TEXT NULL,
+                action_url VARCHAR(255) NULL,
+                data JSON NULL,
+                read_at TIMESTAMP NULL DEFAULT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                INDEX idx_notifications_user_read (user_id, read_at),
+                CONSTRAINT fk_notifications_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+            SQL;
+            $this->db->exec($sql);
+            return;
+        }
+
+        $sql = <<<SQL
+        CREATE TABLE IF NOT EXISTS notifications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            type TEXT NULL,
+            title TEXT NOT NULL,
+            body TEXT NULL,
+            action_url TEXT NULL,
+            data TEXT NULL,
+            read_at TEXT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        SQL;
+        $this->db->exec($sql);
+        $this->db->exec('CREATE INDEX IF NOT EXISTS idx_notifications_user_read ON notifications (user_id, read_at)');
+    }
+
+    public function create(array $attributes): array
+    {
+        $userId = (int) ($attributes['user_id'] ?? 0);
+        $title = trim((string) ($attributes['title'] ?? ''));
+
+        if ($userId <= 0) {
+            throw new RuntimeException('El destinatario de la notificación no es válido.');
+        }
+
+        if ($title === '') {
+            throw new RuntimeException('El título de la notificación es obligatorio.');
+        }
+
+        $now = (new DateTimeImmutable('now'))->format('Y-m-d H:i:s');
+        $type = $this->sanitizeNullableString($attributes['type'] ?? null, 100);
+        $body = $this->sanitizeNullableString($attributes['body'] ?? null);
+        $actionUrl = $this->sanitizeNullableString($attributes['action_url'] ?? null, 255);
+        $data = $this->encodeData($attributes['data'] ?? null);
+
+        $statement = $this->db->prepare(
+            'INSERT INTO notifications (user_id, type, title, body, action_url, data, read_at, created_at, updated_at)'
+            . ' VALUES (:user_id, :type, :title, :body, :action_url, :data, NULL, :created_at, :updated_at)'
+        );
+
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->bindValue(':type', $type);
+        $statement->bindValue(':title', $title);
+        $statement->bindValue(':body', $body);
+        $statement->bindValue(':action_url', $actionUrl);
+        $statement->bindValue(':data', $data);
+        $statement->bindValue(':created_at', $now);
+        $statement->bindValue(':updated_at', $now);
+
+        if (!$statement->execute()) {
+            throw new RuntimeException('No fue posible guardar la notificación.');
+        }
+
+        $id = (int) $this->db->lastInsertId();
+        $notification = $this->find($id);
+
+        if (!$notification) {
+            throw new RuntimeException('No fue posible recuperar la notificación creada.');
+        }
+
+        return $notification;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function allForUser(int $userId, int $limit = 15, bool $onlyUnread = false): array
+    {
+        $userId = max(0, $userId);
+        $limit = max(1, min($limit, 50));
+
+        $sql = 'SELECT * FROM notifications WHERE user_id = :user_id';
+        if ($onlyUnread) {
+            $sql .= ' AND read_at IS NULL';
+        }
+        $sql .= ' ORDER BY created_at DESC, id DESC LIMIT :limit';
+
+        $statement = $this->db->prepare($sql);
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $statement->execute();
+
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        return array_map(fn (array $row): array => $this->formatRow($row), $rows);
+    }
+
+    public function countUnreadForUser(int $userId): int
+    {
+        $statement = $this->db->prepare('SELECT COUNT(*) AS total FROM notifications WHERE user_id = :user_id AND read_at IS NULL');
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->execute();
+
+        $result = $statement->fetch(PDO::FETCH_ASSOC);
+        return (int) ($result['total'] ?? 0);
+    }
+
+    public function markAsRead(int $notificationId, int $userId): void
+    {
+        $this->markManyAsRead([$notificationId], $userId);
+    }
+
+    /**
+     * @param int[] $notificationIds
+     */
+    public function markManyAsRead(array $notificationIds, int $userId): void
+    {
+        $ids = array_values(array_filter(array_map(static fn ($id) => (int) $id, $notificationIds), static fn (int $id) => $id > 0));
+        if ($ids === []) {
+            return;
+        }
+
+        $now = (new DateTimeImmutable('now'))->format('Y-m-d H:i:s');
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $sql = sprintf(
+            'UPDATE notifications SET read_at = ?, updated_at = ? WHERE user_id = ? AND id IN (%s)',
+            $placeholders
+        );
+
+        $statement = $this->db->prepare($sql);
+        $statement->bindValue(1, $now);
+        $statement->bindValue(2, $now);
+        $statement->bindValue(3, $userId, PDO::PARAM_INT);
+
+        $offset = 3;
+        foreach ($ids as $index => $id) {
+            $statement->bindValue($offset + $index + 1, $id, PDO::PARAM_INT);
+        }
+
+        $statement->execute();
+    }
+
+    public function markAllForUser(int $userId): void
+    {
+        $now = (new DateTimeImmutable('now'))->format('Y-m-d H:i:s');
+        $statement = $this->db->prepare('UPDATE notifications SET read_at = :read_at, updated_at = :updated_at WHERE user_id = :user_id AND read_at IS NULL');
+        $statement->bindValue(':read_at', $now);
+        $statement->bindValue(':updated_at', $now);
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->execute();
+    }
+
+    public function find(int $notificationId): ?array
+    {
+        if ($notificationId <= 0) {
+            return null;
+        }
+
+        $statement = $this->db->prepare('SELECT * FROM notifications WHERE id = :id LIMIT 1');
+        $statement->bindValue(':id', $notificationId, PDO::PARAM_INT);
+        $statement->execute();
+
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+        if (!$row) {
+            return null;
+        }
+
+        return $this->formatRow($row);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function formatRow(array $row): array
+    {
+        $data = null;
+        if (array_key_exists('data', $row) && $row['data'] !== null && $row['data'] !== '') {
+            $decoded = json_decode((string) $row['data'], true);
+            $data = is_array($decoded) ? $decoded : null;
+        }
+
+        $createdAt = $this->sanitizeNullableString($row['created_at'] ?? null);
+        $readAt = $this->sanitizeNullableString($row['read_at'] ?? null);
+
+        return [
+            'id' => (int) ($row['id'] ?? 0),
+            'user_id' => (int) ($row['user_id'] ?? 0),
+            'type' => $this->sanitizeNullableString($row['type'] ?? null),
+            'title' => (string) ($row['title'] ?? ''),
+            'body' => $this->sanitizeNullableString($row['body'] ?? null),
+            'action_url' => $this->sanitizeNullableString($row['action_url'] ?? null),
+            'data' => $data,
+            'read_at' => $readAt,
+            'created_at' => $createdAt,
+            'updated_at' => $this->sanitizeNullableString($row['updated_at'] ?? null),
+            'formatted_time' => $this->formatTimestamp($createdAt),
+            'is_unread' => $readAt === null,
+        ];
+    }
+
+    private function sanitizeNullableString(mixed $value, ?int $maxLength = null): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        if ($maxLength !== null && $maxLength > 0) {
+            if (function_exists('mb_substr')) {
+                $value = mb_substr($value, 0, $maxLength);
+            } else {
+                $value = substr($value, 0, $maxLength);
+            }
+        }
+
+        return $value;
+    }
+
+    private function encodeData(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    private function formatTimestamp(?string $value): ?string
+    {
+        if (!$value) {
+            return null;
+        }
+
+        try {
+            $date = new DateTimeImmutable($value);
+        } catch (\Throwable) {
+            return $value;
+        }
+
+        return $date->format('d/m/Y H:i');
+    }
+}

--- a/app/Views/dashboard/components/layout/header.php
+++ b/app/Views/dashboard/components/layout/header.php
@@ -17,11 +17,32 @@
       </label>
     </div>
 
+    <?php
+      $unreadCount = isset($unreadNotificationCount) ? (int) $unreadNotificationCount : 0;
+      $unreadLabel = $unreadCount > 9 ? '9+' : (string) $unreadCount;
+    ?>
+
     <div class="ml-auto flex items-center gap-1 sm:gap-2">
-      <button class="relative inline-flex h-9 w-9 items-center justify-center rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800" aria-label="Notificaciones">
-        <i data-lucide="bell" class="h-5 w-5"></i>
-        <span class="absolute right-1 top-1 h-2 w-2 rounded-full bg-rose-500"></span>
-      </button>
+      <div class="relative">
+        <button
+          type="button"
+          class="relative inline-flex h-9 w-9 items-center justify-center rounded-xl hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:hover:bg-slate-800"
+          data-notifications-toggle
+          data-notifications-count="<?= (int) $unreadCount; ?>"
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-controls="notificationsPanel"
+        >
+          <span class="sr-only">Abrir notificaciones</span>
+          <i data-lucide="bell" class="h-5 w-5"></i>
+          <span
+            data-notifications-badge
+            class="absolute -right-0.5 -top-0.5 min-h-[1.2rem] min-w-[1.2rem] rounded-full bg-rose-500 px-1 text-center text-[10px] font-semibold leading-4 text-white <?= $unreadCount > 0 ? '' : 'hidden'; ?>"
+          >
+            <?= e($unreadLabel); ?>
+          </span>
+        </button>
+      </div>
 
       <div class="inline-flex overflow-hidden rounded-xl border border-slate-200 dark:border-slate-800" role="group" aria-label="Cambiar tema">
         <button id="btnLight" class="flex h-9 w-9 items-center justify-center" title="Modo claro">

--- a/app/Views/dashboard/components/layout/notifications-panel.php
+++ b/app/Views/dashboard/components/layout/notifications-panel.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+$notificationItems = [];
+if (isset($notifications) && is_array($notifications)) {
+    foreach ($notifications as $item) {
+        if (is_array($item)) {
+            $notificationItems[] = $item;
+        }
+    }
+}
+
+$unreadCount = isset($unreadNotificationCount) ? max(0, (int) $unreadNotificationCount) : 0;
+$hasNotifications = $notificationItems !== [];
+?>
+
+<div
+  id="notificationsPanel"
+  class="notifications-panel fixed right-4 top-16 z-50 hidden w-80 max-w-[95vw] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl transition-opacity duration-200 dark:border-slate-800 dark:bg-slate-900"
+  role="dialog"
+  aria-modal="false"
+  aria-labelledby="notificationsPanelTitle"
+  data-notifications-panel
+>
+  <div class="flex items-center justify-between border-b border-slate-200/70 bg-slate-50 px-4 py-3 dark:border-slate-800/70 dark:bg-slate-900/70">
+    <div>
+      <p id="notificationsPanelTitle" class="text-sm font-semibold text-slate-800 dark:text-slate-100">Notificaciones</p>
+      <p class="text-xs text-slate-500 dark:text-slate-400">Actualizaciones de tus proyectos y avances</p>
+    </div>
+    <div class="flex items-center gap-1">
+      <button
+        type="button"
+        class="rounded-lg px-2 py-1 text-xs font-medium text-indigo-600 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:text-indigo-300 dark:hover:bg-indigo-500/10"
+        data-notifications-mark-all
+        <?= $unreadCount > 0 ? '' : 'disabled'; ?>
+      >
+        Marcar como leidas
+      </button>
+      <button
+        type="button"
+        class="rounded-lg p-1 text-slate-500 transition hover:bg-slate-200/60 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:text-slate-400 dark:hover:bg-slate-700/80"
+        data-notifications-close
+        aria-label="Cerrar panel de notificaciones"
+      >
+        <i data-lucide="x" class="h-4 w-4"></i>
+      </button>
+    </div>
+  </div>
+
+  <div class="max-h-96 overflow-y-auto" data-notifications-container>
+    <div data-notifications-loading class="hidden px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+      Cargando notificaciones...
+    </div>
+    <div data-notifications-error class="hidden px-4 py-6 text-center text-sm text-rose-600 dark:text-rose-400">
+      No pudimos cargar las notificaciones. Intenta de nuevo.
+    </div>
+    <p
+      data-notifications-empty
+      class="<?= $hasNotifications ? 'hidden' : ''; ?> px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400"
+    >
+      Aun no tienes notificaciones.
+    </p>
+    <ul data-notifications-list class="divide-y divide-slate-100 dark:divide-slate-800/80">
+      <?php foreach ($notificationItems as $notification): ?>
+        <?php
+          $isUnread = ($notification['is_unread'] ?? false) || empty($notification['read_at'] ?? null);
+          $actionUrl = isset($notification['action_url']) ? trim((string) $notification['action_url']) : '';
+          $hasAction = $actionUrl !== '';
+          $wrapperClasses = 'flex gap-3 px-4 py-3 transition hover:bg-slate-100 dark:hover:bg-slate-800/70';
+          if ($isUnread) {
+              $wrapperClasses .= ' bg-slate-50 dark:bg-slate-800/60';
+          }
+          $timeLabel = format_dashboard_notification_time($notification['created_at'] ?? null);
+          $title = (string) ($notification['title'] ?? '');
+          $body = trim((string) ($notification['body'] ?? ''));
+        ?>
+        <li
+          class="<?= e($wrapperClasses); ?>"
+          data-notification-id="<?= (int) ($notification['id'] ?? 0); ?>"
+          data-notification-read="<?= $isUnread ? 'false' : 'true'; ?>"
+          data-action-url="<?= e($actionUrl); ?>"
+        >
+          <div class="mt-1 flex h-2 w-2 flex-shrink-0 items-center justify-center">
+            <?php if ($isUnread): ?>
+              <span class="inline-block h-2 w-2 rounded-full bg-indigo-500"></span>
+            <?php else: ?>
+              <span class="inline-block h-2 w-2 rounded-full bg-slate-300 dark:bg-slate-600"></span>
+            <?php endif; ?>
+          </div>
+          <div class="min-w-0 flex-1">
+            <?php if ($hasAction): ?>
+              <a href="<?= e($actionUrl); ?>" class="block" data-notification-link>
+            <?php else: ?>
+              <div data-notification-link>
+            <?php endif; ?>
+                <p class="truncate text-sm font-semibold text-slate-800 dark:text-slate-100">
+                  <?= e($title); ?>
+                </p>
+                <?php if ($body !== ''): ?>
+                  <p class="mt-0.5 text-xs text-slate-600 line-clamp-2 dark:text-slate-400">
+                    <?= e($body); ?>
+                  </p>
+                <?php endif; ?>
+                <p class="mt-1 text-[11px] uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                  <?= e($timeLabel); ?>
+                </p>
+            <?php if ($hasAction): ?>
+              </a>
+            <?php else: ?>
+              </div>
+            <?php endif; ?>
+          </div>
+        </li>
+      <?php endforeach; ?>
+    </ul>
+  </div>
+</div>

--- a/app/Views/dashboard/components/layout/page.php
+++ b/app/Views/dashboard/components/layout/page.php
@@ -4,6 +4,7 @@
 <?php dashboard_layout('head', $_dashboard); ?>
 <body class="h-full bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
   <?php dashboard_layout('header', $_dashboard); ?>
+  <?php dashboard_layout('notifications-panel', $_dashboard); ?>
 
   <div class="flex w-full gap-0">
     <?php dashboard_layout('sidebar', $_dashboard); ?>

--- a/app/Views/dashboard/components/layout/scripts.php
+++ b/app/Views/dashboard/components/layout/scripts.php
@@ -2,6 +2,11 @@
   (function () {
     const ACTIVE_CLASSES = ['bg-indigo-600', 'text-white', 'shadow-sm'];
     const INACTIVE_CLASSES = ['text-slate-600', 'hover:bg-slate-100', 'dark:text-slate-300', 'dark:hover:bg-slate-800'];
+    const INITIAL_NOTIFICATIONS = <?= json_encode($notifications ?? [], JSON_UNESCAPED_UNICODE); ?>;
+    const INITIAL_UNREAD_COUNT = <?= (int) ($unreadNotificationCount ?? 0); ?>;
+    const NOTIFICATIONS_ENDPOINT = <?= json_encode(url('/notifications')); ?>;
+    const NOTIFICATIONS_MARK_ENDPOINT = <?= json_encode(url('/notifications/read')); ?>;
+    const NOTIFICATIONS_LIMIT = 20;
     const INITIAL_MODAL = <?= json_encode($modalTarget ?? null); ?>;
     let active = <?= json_encode($activeTab ?? 'dashboard'); ?>;
 
@@ -11,11 +16,24 @@
     const sidebarBackdrop = document.getElementById('sidebarBackdrop');
     const btnSidebar = document.getElementById('btnSidebar');
     const body = document.body;
+    const notificationsPanel = document.getElementById('notificationsPanel');
+    const notificationsToggle = document.querySelector('[data-notifications-toggle]');
+    const notificationsBadge = document.querySelector('[data-notifications-badge]');
+    const notificationsList = notificationsPanel ? notificationsPanel.querySelector('[data-notifications-list]') : null;
+    const notificationsEmpty = notificationsPanel ? notificationsPanel.querySelector('[data-notifications-empty]') : null;
+    const notificationsLoading = notificationsPanel ? notificationsPanel.querySelector('[data-notifications-loading]') : null;
+    const notificationsError = notificationsPanel ? notificationsPanel.querySelector('[data-notifications-error]') : null;
+    const notificationsMarkAll = notificationsPanel ? notificationsPanel.querySelector('[data-notifications-mark-all]') : null;
+    const notificationsClose = notificationsPanel ? notificationsPanel.querySelector('[data-notifications-close]') : null;
+    let notifications = Array.isArray(INITIAL_NOTIFICATIONS) ? [...INITIAL_NOTIFICATIONS] : [];
+    let unreadNotifications = Number.isFinite(Number(INITIAL_UNREAD_COUNT)) ? Number(INITIAL_UNREAD_COUNT) : 0;
+    let notificationsLoaded = notifications.length > 0;
+    let notificationsFetching = false;
 
     function setupAutoDismissAlerts(root = document) {
-      const alerts = Array.from(root.querySelectorAll('[data-auto-dismiss]'));
-      alerts.forEach(alert => {
-        if (alert.dataset.autoDismissBound === 'true') {
+        const alerts = Array.from(root.querySelectorAll('[data-auto-dismiss]'));
+        alerts.forEach(alert => {
+            if (alert.dataset.autoDismissBound === 'true') {
           return;
         }
         alert.dataset.autoDismissBound = 'true';
@@ -153,6 +171,7 @@
     document.addEventListener('keydown', event => {
       if (event.key === 'Escape') {
         closeMobileSidebar();
+        closeNotificationsPanel();
       }
     });
 
@@ -278,6 +297,408 @@
           milestoneEndInput && (milestoneEndInput.value = button.dataset.milestoneEnd || '');
         });
       });
+    }
+
+    function updateNotificationsBadge() {
+      if (!notificationsBadge) {
+        return;
+      }
+      if (unreadNotifications > 0) {
+        notificationsBadge.textContent = unreadNotifications > 9 ? '9+' : String(unreadNotifications);
+        notificationsBadge.classList.remove('hidden');
+      } else {
+        notificationsBadge.classList.add('hidden');
+      }
+      notificationsToggle?.setAttribute('data-notifications-count', String(unreadNotifications));
+    }
+
+    function updateNotificationsMarkAllState() {
+      if (!notificationsMarkAll) {
+        return;
+      }
+      if (unreadNotifications > 0) {
+        notificationsMarkAll.removeAttribute('disabled');
+      } else {
+        notificationsMarkAll.setAttribute('disabled', 'disabled');
+      }
+    }
+
+    function updateNotificationsEmptyState() {
+      if (!notificationsEmpty) {
+        return;
+      }
+      const hasItems = Array.isArray(notifications) && notifications.length > 0;
+      notificationsEmpty.classList.toggle('hidden', hasItems);
+    }
+
+    function setNotificationsLoading(state) {
+      if (!notificationsLoading) {
+        return;
+      }
+      notificationsLoading.classList.toggle('hidden', !state);
+    }
+
+    function setNotificationsError(state) {
+      if (!notificationsError) {
+        return;
+      }
+      notificationsError.classList.toggle('hidden', !state);
+    }
+
+    function isNotificationUnread(notification) {
+      if (!notification) {
+        return false;
+      }
+      if (notification.read_at) {
+        return false;
+      }
+      if (typeof notification.is_unread === 'boolean') {
+        return notification.is_unread;
+      }
+      return true;
+    }
+
+    function formatNotificationTime(value) {
+      if (!value) {
+        return 'Hace un momento';
+      }
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return value;
+      }
+      const now = new Date();
+      const diffSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+      if (diffSeconds < 60) {
+        return 'Hace instantes';
+      }
+      const diffMinutes = Math.floor(diffSeconds / 60);
+      if (diffMinutes < 60) {
+        return diffMinutes === 1 ? 'Hace 1 minuto' : `Hace ${diffMinutes} minutos`;
+      }
+      const diffHours = Math.floor(diffMinutes / 60);
+      if (diffHours < 24) {
+        return diffHours === 1 ? 'Hace 1 hora' : `Hace ${diffHours} horas`;
+      }
+      const diffDays = Math.floor(diffHours / 24);
+      if (diffDays < 7) {
+        return diffDays === 1 ? 'Hace 1 dia' : `Hace ${diffDays} dias`;
+      }
+      const day = String(date.getDate()).padStart(2, '0');
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const hours = String(date.getHours()).padStart(2, '0');
+      const minutes = String(date.getMinutes()).padStart(2, '0');
+      return `${day}/${month}/${date.getFullYear()} ${hours}:${minutes}`;
+    }
+
+    function createNotificationElement(notification) {
+      const element = document.createElement('li');
+      const isUnread = isNotificationUnread(notification);
+      const actionUrl = typeof notification?.action_url === 'string' ? notification.action_url : '';
+      element.className = 'flex gap-3 px-4 py-3 transition hover:bg-slate-100 dark:hover:bg-slate-800/70' + (isUnread ? ' bg-slate-50 dark:bg-slate-800/60' : '');
+      element.dataset.notificationId = String(notification?.id ?? '');
+      element.dataset.notificationRead = isUnread ? 'false' : 'true';
+      element.dataset.actionUrl = actionUrl;
+
+      const markerWrapper = document.createElement('div');
+      markerWrapper.className = 'mt-1 flex h-2 w-2 flex-shrink-0 items-center justify-center';
+      const marker = document.createElement('span');
+      marker.className = 'inline-block h-2 w-2 rounded-full ' + (isUnread ? 'bg-indigo-500' : 'bg-slate-300 dark:bg-slate-600');
+      markerWrapper.appendChild(marker);
+
+      const content = document.createElement('div');
+      content.className = 'min-w-0 flex-1';
+
+      const container = actionUrl ? document.createElement('a') : document.createElement('div');
+      if (actionUrl) {
+        container.href = actionUrl;
+        container.className = 'block';
+      }
+      container.dataset.notificationLink = 'true';
+
+      const title = document.createElement('p');
+      title.className = 'truncate text-sm font-semibold text-slate-800 dark:text-slate-100';
+      title.textContent = String(notification?.title ?? '');
+      container.appendChild(title);
+
+      if (typeof notification?.body === 'string' && notification.body.trim() !== '') {
+        const bodyText = document.createElement('p');
+        bodyText.className = 'mt-0.5 text-xs text-slate-600 line-clamp-2 dark:text-slate-400';
+        bodyText.textContent = notification.body.trim();
+        container.appendChild(bodyText);
+      }
+
+      const time = document.createElement('p');
+      time.className = 'mt-1 text-[11px] uppercase tracking-wide text-slate-400 dark:text-slate-500';
+      const formatted = typeof notification?.formatted_time === 'string' && notification.formatted_time !== ''
+        ? notification.formatted_time
+        : formatNotificationTime(notification?.created_at);
+      time.textContent = formatted;
+      container.appendChild(time);
+
+      content.appendChild(container);
+      element.appendChild(markerWrapper);
+      element.appendChild(content);
+
+      return element;
+    }
+
+    function renderNotifications(force = false) {
+      if (!notificationsList) {
+        return;
+      }
+      if (!force && notificationsList.children.length > 0) {
+        updateNotificationsEmptyState();
+        updateNotificationsMarkAllState();
+        return;
+      }
+      notificationsList.innerHTML = '';
+      const items = Array.isArray(notifications) ? notifications : [];
+      items.forEach(notification => {
+        notificationsList.appendChild(createNotificationElement(notification));
+      });
+      updateNotificationsEmptyState();
+      updateNotificationsMarkAllState();
+      lucide.createIcons();
+    }
+
+    function openNotificationsPanel() {
+      if (!notificationsPanel) {
+        return;
+      }
+      notificationsPanel.classList.remove('hidden');
+      notificationsPanel.setAttribute('aria-hidden', 'false');
+      notificationsToggle?.setAttribute('aria-expanded', 'true');
+      setNotificationsError(false);
+      updateNotificationsEmptyState();
+      updateNotificationsMarkAllState();
+      if (!notificationsLoaded) {
+        fetchNotifications();
+      }
+    }
+
+    function closeNotificationsPanel() {
+      if (!notificationsPanel || notificationsPanel.classList.contains('hidden')) {
+        return;
+      }
+      notificationsPanel.classList.add('hidden');
+      notificationsPanel.setAttribute('aria-hidden', 'true');
+      notificationsToggle?.setAttribute('aria-expanded', 'false');
+    }
+
+    function toggleNotificationsPanel() {
+      if (!notificationsPanel) {
+        return;
+      }
+      if (notificationsPanel.classList.contains('hidden')) {
+        openNotificationsPanel();
+      } else {
+        closeNotificationsPanel();
+      }
+    }
+
+    async function fetchNotifications(force = false) {
+      if (notificationsFetching) {
+        return;
+      }
+      if (!force && notificationsLoaded) {
+        return;
+      }
+      notificationsFetching = true;
+      setNotificationsError(false);
+      setNotificationsLoading(true);
+
+      try {
+        const response = await fetch(`${NOTIFICATIONS_ENDPOINT}?limit=${NOTIFICATIONS_LIMIT}`, {
+          headers: { Accept: 'application/json' },
+          credentials: 'same-origin',
+        });
+        if (!response.ok) {
+          throw new Error('Request failed');
+        }
+        const payload = await response.json();
+        const items = Array.isArray(payload?.notifications) ? payload.notifications : [];
+        notifications = items;
+        notificationsLoaded = true;
+        if (typeof payload?.unread_count === 'number') {
+          unreadNotifications = Math.max(0, Number(payload.unread_count));
+        } else {
+          unreadNotifications = items.reduce((count, item) => count + (isNotificationUnread(item) ? 1 : 0), 0);
+        }
+        renderNotifications(true);
+        updateNotificationsBadge();
+      } catch (error) {
+        console.error('No se pudieron cargar las notificaciones', error);
+        setNotificationsError(true);
+      } finally {
+        setNotificationsLoading(false);
+        notificationsFetching = false;
+        updateNotificationsEmptyState();
+        updateNotificationsMarkAllState();
+      }
+    }
+
+    function markLocalNotifications(ids) {
+      if (!Array.isArray(ids) || ids.length === 0) {
+        return;
+      }
+      const idSet = new Set(ids.map(id => Number(id)).filter(id => Number.isFinite(id) && id > 0));
+      if (idSet.size === 0) {
+        return;
+      }
+      const nowIso = new Date().toISOString();
+      notifications = notifications.map(notification => {
+        const notificationId = Number(notification?.id ?? 0);
+        if (!idSet.has(notificationId)) {
+          return notification;
+        }
+        return {
+          ...notification,
+          read_at: notification?.read_at ?? nowIso,
+          is_unread: false,
+        };
+      });
+      idSet.forEach(id => {
+        const item = notificationsList?.querySelector(`[data-notification-id="${id}"]`);
+        if (item) {
+          item.dataset.notificationRead = 'true';
+          item.classList.remove('bg-slate-50', 'dark:bg-slate-800/60');
+          const marker = item.querySelector('span');
+          if (marker) {
+            marker.classList.remove('bg-indigo-500');
+            marker.classList.add('bg-slate-300', 'dark:bg-slate-600');
+          }
+        }
+      });
+      unreadNotifications = notifications.reduce((count, notification) => count + (isNotificationUnread(notification) ? 1 : 0), 0);
+      updateNotificationsBadge();
+      updateNotificationsMarkAllState();
+    }
+
+    async function markNotifications(ids) {
+      if (!Array.isArray(ids) || ids.length === 0) {
+        return;
+      }
+      markLocalNotifications(ids);
+      try {
+        const response = await fetch(NOTIFICATIONS_MARK_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          credentials: 'same-origin',
+          body: JSON.stringify({ ids }),
+        });
+        if (!response.ok) {
+          throw new Error('Request failed');
+        }
+        const payload = await response.json();
+        if (typeof payload?.unread_count === 'number') {
+          unreadNotifications = Math.max(0, Number(payload.unread_count));
+          updateNotificationsBadge();
+          updateNotificationsMarkAllState();
+        }
+      } catch (error) {
+        console.error('No fue posible marcar la notificacion como leida', error);
+        notificationsLoaded = false;
+      }
+    }
+
+    async function markAllNotifications() {
+      if (!Array.isArray(notifications) || notifications.length === 0) {
+        return;
+      }
+      const ids = notifications
+        .map(notification => Number(notification?.id ?? 0))
+        .filter(id => Number.isFinite(id) && id > 0);
+      if (ids.length === 0) {
+        return;
+      }
+      markLocalNotifications(ids);
+      try {
+        const response = await fetch(NOTIFICATIONS_MARK_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          credentials: 'same-origin',
+          body: JSON.stringify({ mark_all: true }),
+        });
+        if (!response.ok) {
+          throw new Error('Request failed');
+        }
+        const payload = await response.json();
+        if (typeof payload?.unread_count === 'number') {
+          unreadNotifications = Math.max(0, Number(payload.unread_count));
+        } else {
+          unreadNotifications = 0;
+        }
+        updateNotificationsBadge();
+        updateNotificationsMarkAllState();
+      } catch (error) {
+        console.error('No fue posible marcar todas las notificaciones como leidas', error);
+        notificationsLoaded = false;
+      }
+    }
+
+    notificationsToggle?.addEventListener('click', () => {
+      toggleNotificationsPanel();
+      if (!notificationsPanel?.classList.contains('hidden') && !notificationsLoaded) {
+        fetchNotifications();
+      }
+    });
+
+    notificationsClose?.addEventListener('click', () => {
+      closeNotificationsPanel();
+    });
+
+    notificationsMarkAll?.addEventListener('click', event => {
+      event.preventDefault();
+      markAllNotifications();
+    });
+
+    notificationsList?.addEventListener('click', event => {
+      const target = event.target instanceof Element ? event.target.closest('[data-notification-link]') : null;
+      if (!target) {
+        return;
+      }
+      const item = target.closest('[data-notification-id]');
+      if (!item) {
+        return;
+      }
+      const id = Number(item.dataset.notificationId || '0');
+      const actionUrl = item.dataset.actionUrl || (target instanceof HTMLAnchorElement ? target.href : '');
+      if (id > 0) {
+        markNotifications([id]);
+      }
+      if (actionUrl) {
+        event.preventDefault();
+        closeNotificationsPanel();
+        window.location.href = actionUrl;
+      }
+    });
+
+    document.addEventListener('click', event => {
+      if (!notificationsPanel || notificationsPanel.classList.contains('hidden')) {
+        return;
+      }
+      const target = event.target instanceof Element ? event.target : null;
+      if (!target) {
+        return;
+      }
+      if (notificationsPanel.contains(target) || notificationsToggle?.contains(target)) {
+        return;
+      }
+      closeNotificationsPanel();
+    });
+
+    updateNotificationsBadge();
+    updateNotificationsMarkAllState();
+    updateNotificationsEmptyState();
+
+    if (notificationsList && notificationsList.children.length === 0 && notifications.length > 0) {
+      renderNotifications(true);
     }
 
     if (INITIAL_MODAL) {

--- a/public/index.php
+++ b/public/index.php
@@ -6,6 +6,7 @@ use App\Controllers\AuthController;
 use App\Controllers\DashboardController;
 use App\Controllers\DeliverablesController;
 use App\Controllers\FeedbackController;
+use App\Controllers\NotificationsController;
 use App\Controllers\MilestonesController;
 use App\Controllers\ProjectsController;
 use App\Controllers\ProfileController;
@@ -17,6 +18,7 @@ $router = new Router();
 
 $router->get('/', [AuthController::class, 'show']);
 $router->get('/dashboard', [DashboardController::class, 'index']);
+$router->get('/notifications', [NotificationsController::class, 'index']);
 $router->get('/projects', static function (): void {
     redirect_to('/dashboard?tab=proyectos');
 });
@@ -39,6 +41,7 @@ $router->post('/milestones/update', [MilestonesController::class, 'update']);
 $router->post('/milestones/delete', [MilestonesController::class, 'destroy']);
 $router->post('/deliverables', [DeliverablesController::class, 'store']);
 $router->post('/feedback', [FeedbackController::class, 'store']);
+$router->post('/notifications/read', [NotificationsController::class, 'markAsRead']);
 $router->post('/profile/avatar', [ProfileController::class, 'updateAvatar']);
 
 $router->dispatch($_SERVER['REQUEST_METHOD'] ?? 'GET', $_SERVER['REQUEST_URI'] ?? '/');


### PR DESCRIPTION
## Summary
- add a Notification model, controller, and routes to persist items, expose an index endpoint, and mark entries as read
- trigger role-aware notifications after deliverable submissions, feedback, milestone status changes, and project lifecycle actions
- surface notifications in the dashboard with a bell badge, slide-out panel, updated helpers, and client-side fetching/mark-as-read logic

## Testing
- php -l app/Controllers/NotificationsController.php
- php -l app/Models/Notification.php
- php -l app/Controllers/DeliverablesController.php
- php -l app/Controllers/FeedbackController.php
- php -l app/Controllers/MilestonesController.php
- php -l app/Controllers/ProjectsController.php
- php -l app/Controllers/DashboardController.php
- php -l app/Views/dashboard/components/layout/header.php
- php -l app/Views/dashboard/components/layout/notifications-panel.php
- php -l app/Views/dashboard/components/layout/page.php
- php -l app/Views/dashboard/components/layout/scripts.php
- php -l app/Views/dashboard/helpers.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e1ecf62ca8832e9210de1f30d8eaf6