### PR TITLE
Add dashboard search endpoint and topbar integration

### DIFF
--- a/app/Controllers/SearchController.php
+++ b/app/Controllers/SearchController.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Core\Controller;
+use App\Helpers\Session;
+use App\Models\Feedback;
+use App\Models\Milestone;
+use App\Models\Project;
+use function json_encode;
+
+class SearchController extends Controller
+{
+    private Project $projects;
+    private Milestone $milestones;
+    private Feedback $feedback;
+
+    public function __construct()
+    {
+        parent::__construct();
+        Session::start();
+        $this->projects = new Project();
+        $this->milestones = new Milestone();
+        $this->feedback = new Feedback();
+    }
+
+    public function index(): void
+    {
+        $user = Session::user();
+        if (!$user) {
+            $this->json(['error' => 'No autorizado'], 401);
+            return;
+        }
+
+        $term = isset($_GET['q']) ? (string) $_GET['q'] : '';
+        $term = trim($term);
+
+        $length = function_exists('mb_strlen') ? mb_strlen($term) : strlen($term);
+        if ($term === '' || $length < 2) {
+            $this->json([
+                'term' => '',
+                'projects' => [],
+                'milestones' => [],
+                'feedback' => [],
+            ]);
+            return;
+        }
+
+        $limit = isset($_GET['limit']) ? (int) $_GET['limit'] : 5;
+        $limit = max(1, min($limit, 10));
+
+        $projects = $this->projects->searchForUser($user, $term, $limit);
+        $milestones = $this->milestones->searchForUser($user, $term, $limit);
+        $feedback = $this->feedback->searchForUser($user, $term, $limit);
+
+        $this->json([
+            'term' => $term,
+            'projects' => array_map(fn (array $item): array => $this->formatProject($item), $projects),
+            'milestones' => array_map(fn (array $item): array => $this->formatMilestone($item), $milestones),
+            'feedback' => array_map(fn (array $item): array => $this->formatFeedback($item), $feedback),
+        ]);
+    }
+
+    private function formatProject(array $project): array
+    {
+        $id = (int) ($project['id'] ?? 0);
+
+        return [
+            'id' => $id,
+            'title' => (string) ($project['title'] ?? ''),
+            'description' => $this->snippet($project['description'] ?? null),
+            'meta' => $this->humanizeStatus((string) ($project['status'] ?? '')),
+            'url' => $id > 0 ? \url('/dashboard?tab=proyectos&project=' . $id) : \url('/dashboard?tab=proyectos'),
+            'icon' => 'briefcase',
+        ];
+    }
+
+    private function formatMilestone(array $milestone): array
+    {
+        $id = (int) ($milestone['id'] ?? 0);
+        $projectId = (int) ($milestone['project_id'] ?? 0);
+        $status = $this->humanizeStatus((string) ($milestone['status'] ?? ''));
+        $projectTitle = (string) ($milestone['project_title'] ?? '');
+        $meta = $projectTitle !== '' ? $status . ' • ' . $projectTitle : $status;
+
+        return [
+            'id' => $id,
+            'title' => (string) ($milestone['title'] ?? ''),
+            'description' => $this->snippet($milestone['description'] ?? null),
+            'meta' => $meta,
+            'url' => $projectId > 0
+                ? \url('/dashboard?tab=hitos&project=' . $projectId . '#milestone-' . $id)
+                : \url('/dashboard?tab=hitos'),
+            'icon' => 'flag',
+        ];
+    }
+
+    private function formatFeedback(array $feedback): array
+    {
+        $id = (int) ($feedback['id'] ?? 0);
+        $projectId = (int) ($feedback['project_id'] ?? 0);
+        $content = (string) ($feedback['content'] ?? '');
+        $milestoneTitle = (string) ($feedback['milestone_title'] ?? '');
+        $projectTitle = (string) ($feedback['project_title'] ?? '');
+        $author = (string) ($feedback['author_name'] ?? '');
+
+        $descriptionParts = [];
+        if ($milestoneTitle !== '') {
+            $descriptionParts[] = 'Hito: ' . $milestoneTitle;
+        }
+        if ($author !== '') {
+            $descriptionParts[] = 'Autor: ' . $author;
+        }
+
+        $meta = $projectTitle !== '' ? 'Proyecto: ' . $projectTitle : '';
+
+        return [
+            'id' => $id,
+            'title' => $this->snippet($content),
+            'description' => implode(' • ', $descriptionParts),
+            'meta' => $meta,
+            'url' => $projectId > 0
+                ? \url('/dashboard?tab=comentarios&project=' . $projectId . '#comentario-' . $id)
+                : \url('/dashboard?tab=comentarios'),
+            'icon' => 'message-circle',
+        ];
+    }
+
+    private function snippet(?string $value, int $length = 120): string
+    {
+        $text = trim((string) $value);
+        if ($text === '') {
+            return '';
+        }
+
+        if (function_exists('mb_strlen') && function_exists('mb_substr')) {
+            if (mb_strlen($text) <= $length) {
+                return $text;
+            }
+
+            return rtrim(mb_substr($text, 0, $length - 1)) . '…';
+        }
+
+        if (strlen($text) <= $length) {
+            return $text;
+        }
+
+        return rtrim(substr($text, 0, $length - 1)) . '…';
+    }
+
+    private function humanizeStatus(string $status): string
+    {
+        $map = [
+            'planificado' => 'Planificado',
+            'en_progreso' => 'En progreso',
+            'en_riesgo' => 'En riesgo',
+            'completado' => 'Completado',
+            'pendiente' => 'Pendiente',
+            'en_revision' => 'En revisión',
+            'aprobado' => 'Aprobado',
+        ];
+
+        if (isset($map[$status])) {
+            return $map[$status];
+        }
+
+        $status = str_replace('_', ' ', $status);
+        return $status !== '' ? ucfirst($status) : '';
+    }
+
+    private function json(array $data, int $status = 200): void
+    {
+        http_response_code($status);
+        header('Content-Type: application/json; charset=UTF-8');
+        echo json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/app/Views/dashboard/components/layout/header.php
+++ b/app/Views/dashboard/components/layout/header.php
@@ -10,11 +10,34 @@
     </div>
 
     <div class="mx-3 hidden flex-1 items-center sm:flex">
-      <label class="relative w-full max-w-xl">
+      <div class="relative w-full max-w-xl" data-global-search>
+        <label for="globalSearchInput" class="sr-only">Buscar</label>
         <i data-lucide="search" class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400"></i>
-        <span class="sr-only">Buscar</span>
-        <input type="text" placeholder="Buscar proyecto, hito, comentario..." class="w-full rounded-xl border border-slate-200 bg-slate-50 pl-9 pr-3 py-2 text-sm outline-none placeholder:text-slate-400 focus:border-indigo-500 focus:bg-white dark:border-slate-700 dark:bg-slate-800 dark:focus:border-indigo-400" />
-      </label>
+        <input
+          id="globalSearchInput"
+          type="search"
+          placeholder="Buscar proyecto, hito, comentario..."
+          autocomplete="off"
+          spellcheck="false"
+          class="w-full rounded-xl border border-slate-200 bg-slate-50 py-2 pl-9 pr-3 text-sm outline-none placeholder:text-slate-400 focus:border-indigo-500 focus:bg-white dark:border-slate-700 dark:bg-slate-800 dark:focus:border-indigo-400"
+          data-global-search-input
+        />
+        <div
+          data-global-search-panel
+          class="absolute left-0 right-0 top-full z-40 mt-2 hidden overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl shadow-slate-200/70 dark:border-slate-700 dark:bg-slate-900"
+        >
+          <div data-global-search-loading class="border-b border-slate-100 bg-slate-50 px-4 py-3 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-300 hidden">
+            Buscando…
+          </div>
+          <div data-global-search-error class="border-b border-rose-100 bg-rose-50/80 px-4 py-3 text-sm text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-200 hidden">
+            Ocurrió un error al buscar. Intenta nuevamente.
+          </div>
+          <div data-global-search-empty class="border-b border-slate-100 bg-slate-50/60 px-4 py-3 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-300 hidden">
+            No se encontraron coincidencias.
+          </div>
+          <div data-global-search-list class="max-h-80 overflow-y-auto bg-white dark:bg-slate-900" role="listbox"></div>
+        </div>
+      </div>
     </div>
 
     <?php

--- a/app/Views/dashboard/components/sections/comments.php
+++ b/app/Views/dashboard/components/sections/comments.php
@@ -46,7 +46,7 @@ foreach ($projectMilestonesList as $milestone) {
                   <p class="rounded-xl border border-dashed border-slate-300/80 bg-slate-50/70 px-3 py-3 text-center text-xs text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/50">Sin comentarios registrados.</p>
                 <?php else: ?>
                   <?php foreach ($feedbackList as $comment): ?>
-                    <article class="rounded-xl border border-slate-200/70 bg-white/90 px-3 py-3 text-sm shadow-sm transition hover:border-emerald-200 hover:bg-white dark:border-slate-800/70 dark:bg-slate-950/40 dark:hover:border-emerald-900/50">
+                    <article id="comentario-<?= e((string) $comment['id']); ?>" class="rounded-xl border border-slate-200/70 bg-white/90 px-3 py-3 text-sm shadow-sm transition hover:border-emerald-200 hover:bg-white dark:border-slate-800/70 dark:bg-slate-950/40 dark:hover:border-emerald-900/50">
                       <div class="flex flex-wrap items-center justify-between gap-2 text-[11px] text-slate-400">
                         <span class="font-semibold text-slate-600 dark:text-slate-200"><?= e($comment['author_name']); ?></span>
                         <span><?= e(format_dashboard_date($comment['created_at'] ?? null)); ?></span>

--- a/app/Views/dashboard/components/sections/milestones.php
+++ b/app/Views/dashboard/components/sections/milestones.php
@@ -81,7 +81,7 @@
                 $milestoneStatusClasses = trim('inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-wide shadow-sm ring-1 ring-inset ring-black/5 dark:ring-white/10 ' . (status_badge_classes($milestone['status']) ?? 'bg-slate-200 text-slate-600'));
                 $milestoneDeliverablesCount = (int) ($milestone['deliverables_count'] ?? count($deliverables));
               ?>
-              <article class="group relative overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/70 dark:bg-slate-900/60 dark:shadow-none">
+              <article id="milestone-<?= e((string) $milestone['id']); ?>" class="group relative overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/70 dark:bg-slate-900/60 dark:shadow-none">
                 <div class="flex flex-col gap-5">
                   <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                     <div class="space-y-3"><h4 class="text-base font-semibold text-slate-800 dark:text-slate-100"><?= e($milestone['title']); ?></h4>

--- a/public/index.php
+++ b/public/index.php
@@ -10,6 +10,7 @@ use App\Controllers\NotificationsController;
 use App\Controllers\MilestonesController;
 use App\Controllers\ProjectsController;
 use App\Controllers\ProfileController;
+use App\Controllers\SearchController;
 use App\Core\Router;
 
 require __DIR__ . '/../app/bootstrap.php';
@@ -19,6 +20,7 @@ $router = new Router();
 $router->get('/', [AuthController::class, 'show']);
 $router->get('/dashboard', [DashboardController::class, 'index']);
 $router->get('/notifications', [NotificationsController::class, 'index']);
+$router->get('/search', [SearchController::class, 'index']);
 $router->get('/projects', static function (): void {
     redirect_to('/dashboard?tab=proyectos');
 });


### PR DESCRIPTION
## Summary
- add a SearchController that exposes an authenticated `/search` endpoint returning project, milestone, and feedback hits
- extend project, milestone, and feedback models with scoped search helpers used by the controller
- refresh the dashboard header and scripts to provide an interactive global search dropdown and deep-link anchors

## Testing
- php -l app/Controllers/SearchController.php
- php -l app/Models/Project.php
- php -l app/Models/Milestone.php
- php -l app/Models/Feedback.php


------
https://chatgpt.com/codex/tasks/task_e_68e22a79e4f8832e828ef363fa49e267