### PR TITLE
feat: standardize module shadows and mark required fields

### DIFF
--- a/app/Views/auth/index.php
+++ b/app/Views/auth/index.php
@@ -148,7 +148,7 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
                 <?php endif; ?>
 
                 <div>
-                  <label for="login-email" class="mb-2 block text-sm font-semibold text-slate-700">Correo institucional</label>
+                  <label for="login-email" class="mb-2 block text-sm font-semibold text-slate-700">Correo institucional <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
                   <input id="login-email" type="email" name="email" required value="<?= $oldValue('login_email'); ?>" class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('login_email') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="correo@itmerida.edu.mx" autocomplete="email" />
                   <?php if ($hasError('login_email')): ?>
                     <p class="mt-2 text-xs font-medium text-red-600"><?= e($errorText('login_email')); ?></p>
@@ -157,7 +157,7 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
 
                 <div>
                   <div class="mb-2 flex items-center justify-between">
-                    <label for="password" class="block text-sm font-semibold text-slate-700">Contraseña</label>
+                    <label for="password" class="block text-sm font-semibold text-slate-700">Contraseña <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
                   </div>
                   <div class="relative">
                     <input id="password" type="password" name="password" required class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 pr-12 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('login_password') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="Tu contraseña" autocomplete="current-password" />
@@ -199,7 +199,7 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
                 <?php endif; ?>
 
                 <div>
-                  <label for="full_name" class="mb-2 block text-sm font-semibold text-slate-700">Nombre completo</label>
+                  <label for="full_name" class="mb-2 block text-sm font-semibold text-slate-700">Nombre completo <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
                   <input id="full_name" type="text" name="full_name" required value="<?= $oldValue('full_name'); ?>" class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('full_name') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="Nombre y apellidos" autocomplete="name" />
                   <?php if ($hasError('full_name')): ?>
                     <p class="mt-2 text-xs font-medium text-red-600"><?= e($errorText('full_name')); ?></p>
@@ -207,7 +207,7 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
                 </div>
 
                 <div>
-                  <label for="register-email" class="mb-2 block text-sm font-semibold text-slate-700">Correo institucional</label>
+                  <label for="register-email" class="mb-2 block text-sm font-semibold text-slate-700">Correo institucional <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
                   <input id="register-email" type="email" name="email" required value="<?= $oldValue('email'); ?>" class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('email') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="correo@itmerida.edu.mx" autocomplete="email" />
                   <?php if ($hasError('email')): ?>
                     <p class="mt-2 text-xs font-medium text-red-600"><?= e($errorText('email')); ?></p>
@@ -239,7 +239,7 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
                 </div>
 
                 <div>
-                  <label for="register-password" class="mb-2 block text-sm font-semibold text-slate-700">Contraseña</label>
+                  <label for="register-password" class="mb-2 block text-sm font-semibold text-slate-700">Contraseña <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
                   <div class="relative">
                     <input id="register-password" type="password" name="password" required class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 pr-12 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('password') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="Minimo 8 caracteres" autocomplete="new-password" />
                     <button type="button" class="toggle-eye absolute inset-y-0 right-0 flex items-center pr-4 text-slate-400 hover:text-slate-600" data-toggle-for="register-password" aria-label="Mostrar contraseña">
@@ -255,7 +255,7 @@ $roleValue = in_array($roleValue, ['estudiante', 'director'], true) ? $roleValue
                 </div>
 
                 <div>
-                  <label for="password_confirmation" class="mb-2 block text-sm font-semibold text-slate-700">Confirmar contraseña</label>
+                  <label for="password_confirmation" class="mb-2 block text-sm font-semibold text-slate-700">Confirmar contraseña <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
                   <div class="relative">
                     <input id="password_confirmation" type="password" name="password_confirmation" required class="block w-full rounded-xl border border-slate-200 bg-white px-4 py-3 pr-12 text-sm shadow-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 <?= $hasError('password_confirmation') ? 'border-red-400 focus:border-red-500 focus:ring-red-200' : 'focus:border-indigo-500 focus:ring-indigo-200'; ?>" placeholder="Repite la contraseña" autocomplete="new-password" />
                     <button type="button" class="toggle-eye absolute inset-y-0 right-0 flex items-center pr-4 text-slate-400 hover:text-slate-600" data-toggle-for="password_confirmation" aria-label="Mostrar contraseña">

--- a/app/Views/auth/password_change.php
+++ b/app/Views/auth/password_change.php
@@ -63,7 +63,7 @@ $tokenError = $tokenError ?? null;
           </div>
 
           <div>
-            <label for="password" class="mb-2 block text-sm font-semibold text-slate-700">Nueva contrase&ntilde;a</label>
+            <label for="password" class="mb-2 block text-sm font-semibold text-slate-700">Nueva contrase&ntilde;a <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <input
               id="password"
               type="password"
@@ -80,7 +80,7 @@ $tokenError = $tokenError ?? null;
           </div>
 
           <div>
-            <label for="password_confirmation" class="mb-2 block text-sm font-semibold text-slate-700">Confirma tu nueva contrase&ntilde;a</label>
+            <label for="password_confirmation" class="mb-2 block text-sm font-semibold text-slate-700">Confirma tu nueva contrase&ntilde;a <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <input
               id="password_confirmation"
               type="password"
@@ -104,7 +104,7 @@ $tokenError = $tokenError ?? null;
           </button>
         <?php else: ?>
           <div>
-            <label for="email" class="mb-2 block text-sm font-semibold text-slate-700">Correo institucional</label>
+            <label for="email" class="mb-2 block text-sm font-semibold text-slate-700">Correo institucional <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <input
               id="email"
               type="email"

--- a/app/Views/dashboard/components/layout/header.php
+++ b/app/Views/dashboard/components/layout/header.php
@@ -24,7 +24,7 @@
         />
         <div
           data-global-search-panel
-          class="absolute left-0 right-0 top-full z-40 mt-2 hidden overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl shadow-slate-200/70 dark:border-slate-700 dark:bg-slate-900"
+          class="absolute left-0 right-0 top-full z-40 mt-2 hidden overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-lg shadow-slate-200/70 dark:border-slate-700 dark:bg-slate-900"
         >
           <div data-global-search-loading class="border-b border-slate-100 bg-slate-50 px-4 py-3 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-300 hidden">
             Buscando…

--- a/app/Views/dashboard/components/layout/notifications-panel.php
+++ b/app/Views/dashboard/components/layout/notifications-panel.php
@@ -17,7 +17,7 @@ $hasNotifications = $notificationItems !== [];
 
 <div
   id="notificationsPanel"
-  class="notifications-panel fixed right-4 top-16 z-50 hidden w-80 max-w-[95vw] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl transition-opacity duration-200 dark:border-slate-800 dark:bg-slate-900"
+  class="notifications-panel fixed right-4 top-16 z-50 hidden w-80 max-w-[95vw] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-lg transition-opacity duration-200 dark:border-slate-800 dark:bg-slate-900"
   role="dialog"
   aria-modal="false"
   aria-labelledby="notificationsPanelTitle"

--- a/app/Views/dashboard/components/layout/sidebar.php
+++ b/app/Views/dashboard/components/layout/sidebar.php
@@ -3,7 +3,7 @@ $active = $activeTab ?? 'dashboard';
 ?>
 <aside
   id="sidebar"
-  class="fixed inset-y-0 left-0 z-40 w-64 -translate-x-full transform border-r border-slate-200 bg-white p-4 shadow-xl transition-transform transition-width duration-300 dark:border-slate-800 dark:bg-slate-900 md:sticky md:top-14 md:h-[calc(100vh-3.5rem)] md:translate-x-0 md:p-2 md:shadow-none"
+  class="fixed inset-y-0 left-0 z-40 w-64 -translate-x-full transform border-r border-slate-200 bg-white p-4 shadow-lg transition-transform transition-width duration-300 dark:border-slate-800 dark:bg-slate-900 md:sticky md:top-14 md:h-[calc(100vh-3.5rem)] md:translate-x-0 md:p-2 md:shadow-none"
   aria-label="Navegacion principal"
   aria-hidden="true"
 >

--- a/app/Views/dashboard/components/modals/milestone-edit.php
+++ b/app/Views/dashboard/components/modals/milestone-edit.php
@@ -10,7 +10,7 @@
 
 <div id="modalMilestoneEdit" class="modal hidden">
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-3 py-6">
-    <div class="w-full max-w-xl rounded-2xl border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+    <div class="w-full max-w-xl rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-900">
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-semibold">Editar hito</h2>
         <button data-modal-close class="rounded-full p-1 text-slate-500 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800" type="button">
@@ -25,7 +25,7 @@
           <input type="hidden" name="return_anchor" value="<?= e('milestone-' . (string) ($milestoneEditValues['milestone_id'] ?? $milestoneEditId)); ?>" />
         <?php endif; ?>
         <div>
-          <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-edit-title">Titulo</label>
+          <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-edit-title">Titulo <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
           <input
             id="milestone-edit-title"
             type="text"
@@ -47,7 +47,7 @@
         </div>
         <div class="grid gap-3 sm:grid-cols-2">
           <div>
-            <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-edit-start-date">Fecha de inicio</label>
+            <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-edit-start-date">Fecha de inicio <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <input
               id="milestone-edit-start-date"
               type="date"
@@ -58,7 +58,7 @@
             />
           </div>
           <div>
-            <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-edit-end-date">Fecha de finalizacion</label>
+            <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-edit-end-date">Fecha de finalizacion <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <input
               id="milestone-edit-end-date"
               type="date"

--- a/app/Views/dashboard/components/modals/milestone.php
+++ b/app/Views/dashboard/components/modals/milestone.php
@@ -4,7 +4,7 @@
 
 <div id="modalMilestone" class="modal hidden">
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-3 py-6">
-    <div class="w-full max-w-xl rounded-2xl border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+    <div class="w-full max-w-xl rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-900">
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-semibold">Nuevo hito</h2>
         <button data-modal-close class="rounded-full p-1 text-slate-500 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800" type="button">
@@ -16,7 +16,7 @@
         <input type="hidden" name="return_tab" value="<?= e((string) ($activeTab ?? 'dashboard')); ?>" />
         <input type="hidden" name="return_project" value="<?= e((string) $selectedProject['id']); ?>" />
         <div>
-          <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-title">Título</label>
+          <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-title">Título <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
           <input id="milestone-title" type="text" name="title" value="<?= e((string) ($milestoneOld['title'] ?? '')); ?>" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900" required />
         </div>
         <div>
@@ -25,11 +25,11 @@
         </div>
         <div class="grid gap-3 sm:grid-cols-2">
           <div>
-            <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-start-date">Fecha de inicio</label>
+            <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-start-date">Fecha de inicio <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <input id="milestone-start-date" type="date" name="start_date" value="<?= e((string) ($milestoneOld['start_date'] ?? $milestoneOld['due_date'] ?? '')); ?>" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900" required />
           </div>
           <div>
-            <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-end-date">Fecha de finalización</label>
+            <label class="text-xs font-semibold uppercase text-slate-500" for="milestone-end-date">Fecha de finalización <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <input id="milestone-end-date" type="date" name="end_date" value="<?= e((string) ($milestoneOld['end_date'] ?? $milestoneOld['due_date'] ?? '')); ?>" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900" required />
           </div>
         </div>

--- a/app/Views/dashboard/components/modals/profile.php
+++ b/app/Views/dashboard/components/modals/profile.php
@@ -1,6 +1,6 @@
 <div id="modalProfile" class="modal hidden">
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-3 py-6">
-    <div class="w-full max-w-lg rounded-2xl border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+    <div class="w-full max-w-lg rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-900">
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-semibold">Configuracion de perfil</h2>
         <button data-modal-close class="rounded-full p-1 text-slate-500 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800" type="button">
@@ -29,7 +29,7 @@
         </div>
 
         <div>
-          <label for="profile-avatar" class="text-xs font-semibold uppercase text-slate-500">Selecciona una imagen</label>
+          <label for="profile-avatar" class="text-xs font-semibold uppercase text-slate-500">Selecciona una imagen <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
           <input id="profile-avatar" name="avatar" type="file" accept="image/png,image/jpeg,image/webp,image/gif" class="mt-1 w-full cursor-pointer rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm file:mr-4 file:cursor-pointer file:rounded-lg file:border-0 file:bg-indigo-600 file:px-3 file:py-2 file:text-sm file:font-medium file:text-white hover:file:bg-indigo-700 dark:border-slate-700 dark:bg-slate-900" required />
           <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">Formatos permitidos: JPG, PNG, GIF o WEBP. Peso maximo 5 MB.</p>
         </div>

--- a/app/Views/dashboard/components/modals/project-edit.php
+++ b/app/Views/dashboard/components/modals/project-edit.php
@@ -10,7 +10,7 @@
 
 <div id="modalProjectEdit" class="modal hidden">
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-3 py-6">
-    <div class="w-full max-w-xl rounded-2xl border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+    <div class="w-full max-w-xl rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-900">
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-semibold">Editar proyecto</h2>
         <button data-modal-close class="rounded-full p-1 text-slate-500 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800" type="button">
@@ -25,7 +25,7 @@
           <input type="hidden" name="return_anchor" value="<?= e('project-' . (string) $projectEditFormProjectId); ?>" />
         <?php endif; ?>
         <div>
-          <label class="text-xs font-semibold uppercase text-slate-500" for="project-edit-title">Titulo</label>
+          <label class="text-xs font-semibold uppercase text-slate-500" for="project-edit-title">Titulo <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
           <input
             id="project-edit-title"
             type="text"
@@ -47,7 +47,7 @@
         </div>
         <div class="grid gap-3 sm:grid-cols-2">
           <div>
-            <label class="text-xs font-semibold uppercase text-slate-500" for="project-edit-student">Estudiante</label>
+            <label class="text-xs font-semibold uppercase text-slate-500" for="project-edit-student">Estudiante <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <select
               id="project-edit-student"
               name="student_id"
@@ -66,7 +66,7 @@
             </select>
           </div>
           <div>
-            <label class="text-xs font-semibold uppercase text-slate-500" for="project-edit-start-date">Fecha de inicio</label>
+            <label class="text-xs font-semibold uppercase text-slate-500" for="project-edit-start-date">Fecha de inicio <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <input
               id="project-edit-start-date"
               type="date"
@@ -77,7 +77,7 @@
             />
           </div>
           <div>
-            <label class="text-xs font-semibold uppercase text-slate-500" for="project-edit-end-date">Fecha de finalizacion</label>
+            <label class="text-xs font-semibold uppercase text-slate-500" for="project-edit-end-date">Fecha de finalizacion <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <input
               id="project-edit-end-date"
               type="date"

--- a/app/Views/dashboard/components/modals/project.php
+++ b/app/Views/dashboard/components/modals/project.php
@@ -8,7 +8,7 @@
 
 <div id="modalProject" class="modal hidden">
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-3 py-6">
-    <div class="w-full max-w-xl rounded-2xl border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+    <div class="w-full max-w-xl rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-900">
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-semibold">Nuevo proyecto</h2>
         <button data-modal-close class="rounded-full p-1 text-slate-500 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800" type="button">
@@ -19,7 +19,7 @@
         <input type="hidden" name="return_tab" value="<?= e((string) ($activeTab ?? 'dashboard')); ?>" />
         <input type="hidden" name="return_project" value="<?= e((string) ($projectReturnId ?? '')); ?>" />
         <div>
-          <label class="text-xs font-semibold uppercase text-slate-500" for="project-title">Título</label>
+          <label class="text-xs font-semibold uppercase text-slate-500" for="project-title">Título <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
           <input id="project-title" type="text" name="title" value="<?= e((string) ($projectOld['title'] ?? '')); ?>" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900" required />
         </div>
         <div>
@@ -28,7 +28,7 @@
         </div>
         <div class="grid gap-3 sm:grid-cols-2">
           <div>
-            <label class="text-xs font-semibold uppercase text-slate-500" for="project-student">Estudiante</label>
+            <label class="text-xs font-semibold uppercase text-slate-500" for="project-student">Estudiante <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <select id="project-student" name="student_id" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900" required>
               <option value="">Selecciona una opción</option>
               <?php foreach ($students as $student): ?>
@@ -37,11 +37,11 @@
             </select>
           </div>
           <div>
-            <label class="text-xs font-semibold uppercase text-slate-500" for="project-start-date">Fecha de inicio</label>
+            <label class="text-xs font-semibold uppercase text-slate-500" for="project-start-date">Fecha de inicio <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <input id="project-start-date" type="date" name="start_date" value="<?= e((string) ($projectOld['start_date'] ?? $projectOld['due_date'] ?? '')); ?>" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900" required />
           </div>
           <div>
-            <label class="text-xs font-semibold uppercase text-slate-500" for="project-end-date">Fecha de finalizacion</label>
+            <label class="text-xs font-semibold uppercase text-slate-500" for="project-end-date">Fecha de finalizacion <span class="text-rose-500" aria-hidden="true">*</span><span class="sr-only"> (obligatorio)</span></label>
             <input id="project-end-date" type="date" name="end_date" value="<?= e((string) ($projectOld['end_date'] ?? $projectOld['due_date'] ?? '')); ?>" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-slate-700 dark:bg-slate-900" required />
           </div>
         </div>

--- a/app/Views/dashboard/components/sections/comments.php
+++ b/app/Views/dashboard/components/sections/comments.php
@@ -7,7 +7,7 @@ foreach ($projectMilestonesList as $milestone) {
 }
 ?>
 <section id="section-comentarios" data-section="comentarios" class="space-y-8<?= $isCommentsActive ? '' : ' hidden'; ?>">
-  <article class="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-xl shadow-indigo-100/50 transition dark:border-slate-800/70 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950/70 dark:shadow-none">
+  <article class="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-lg shadow-indigo-100/50 transition dark:border-slate-800/70 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950/70 dark:shadow-none">
     <div class="flex flex-col gap-6">
       <header class="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-300">
         <span class="inline-flex items-center gap-2 rounded-full border border-indigo-200/70 bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 shadow-sm dark:border-indigo-900/60 dark:bg-indigo-950/50 dark:text-indigo-200">
@@ -22,14 +22,14 @@ foreach ($projectMilestonesList as $milestone) {
 
       <div class="space-y-4">
         <?php if ($projectMilestonesList === []): ?>
-          <div class="rounded-2xl border border-dashed border-slate-300 bg-white/70 px-6 py-10 text-center text-sm text-slate-500 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+          <div class="rounded-2xl border border-dashed border-slate-300 bg-white/70 px-6 py-10 text-center text-sm text-slate-500 shadow-lg dark:border-slate-700 dark:bg-slate-900/60">
             <i data-lucide="sparkles" class="mx-auto mb-3 h-6 w-6 text-indigo-400"></i>
             <p class="font-medium text-slate-600 dark:text-slate-200">Selecciona un proyecto con hitos para ver los comentarios.</p>
           </div>
         <?php else: ?>
           <?php foreach ($projectMilestonesList as $milestone): ?>
             <?php $feedbackList = $feedbackByMilestone[$milestone['id']] ?? []; ?>
-            <section class="rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/70 dark:bg-slate-900/60 dark:shadow-none">
+            <section class="rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-lg shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/70 dark:bg-slate-900/60 dark:shadow-none">
               <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                 <div class="space-y-2">
                   <h3 class="text-base font-semibold text-slate-800 dark:text-slate-100"><?= e($milestone['title']); ?></h3>

--- a/app/Views/dashboard/components/sections/dashboard-overview.php
+++ b/app/Views/dashboard/components/sections/dashboard-overview.php
@@ -30,7 +30,7 @@ $upcomingCount = count($upcomingMilestones ?? []);
 $recentFeedbackCount = count($recentFeedback ?? []);
 ?>
 <section id="section-dashboard" data-section="dashboard" class="space-y-8<?= $isDashboardActive ? '' : ' hidden'; ?>">
-  <article class="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-xl shadow-indigo-100/50 transition dark:border-slate-800/70 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950/70 dark:shadow-none">
+  <article class="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-lg shadow-indigo-100/50 transition dark:border-slate-800/70 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950/70 dark:shadow-none">
     <div class="flex flex-col gap-6">
       <header class="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-300">
         <span class="inline-flex items-center gap-2 rounded-full border border-indigo-200/70 bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 shadow-sm dark:border-indigo-900/60 dark:bg-indigo-950/50 dark:text-indigo-200">
@@ -45,7 +45,7 @@ $recentFeedbackCount = count($recentFeedback ?? []);
 
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <?php foreach ($statCards as $card): ?>
-          <article class="rounded-2xl border border-slate-200/60 bg-white/80 p-4 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
+          <article class="rounded-2xl border border-slate-200/60 bg-white/80 p-4 shadow-lg shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
             <div class="flex items-center justify-between">
               <p class="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-300"><?= e($card['label']); ?></p>
               <i data-lucide="<?= e($card['icon']); ?>" class="h-5 w-5 <?= e($card['accent']); ?>"></i>
@@ -56,7 +56,7 @@ $recentFeedbackCount = count($recentFeedback ?? []);
       </div>
 
       <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
-        <article class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
+        <article class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 shadow-lg shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
           <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div class="space-y-1">
               <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Proximos hitos</h2>
@@ -89,7 +89,7 @@ $recentFeedbackCount = count($recentFeedback ?? []);
           </div>
         </article>
 
-        <article class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
+        <article class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 shadow-lg shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
           <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div class="space-y-1">
               <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Feedback reciente</h2>

--- a/app/Views/dashboard/components/sections/milestones.php
+++ b/app/Views/dashboard/components/sections/milestones.php
@@ -1,7 +1,7 @@
 ﻿<?php $isMilestonesActive = ($activeTab ?? 'dashboard') === 'hitos'; ?>
 <section id="section-hitos" data-section="hitos" class="space-y-8<?= $isMilestonesActive ? '' : ' hidden'; ?>">
   <?php if (!$selectedProject): ?>
-    <div class="rounded-3xl border border-dashed border-slate-200 bg-gradient-to-b from-white via-white to-slate-50 px-6 py-12 text-center text-sm text-slate-500 shadow-inner dark:border-slate-800 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
+    <div class="rounded-3xl border border-dashed border-slate-200 bg-gradient-to-b from-white via-white to-slate-50 px-6 py-12 text-center text-sm text-slate-500 shadow-lg dark:border-slate-800 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
       <i data-lucide="target" class="mx-auto mb-4 h-8 w-8 text-indigo-500/70"></i>
       <p class="text-sm font-medium text-slate-600 dark:text-slate-200">Selecciona un proyecto para gestionar sus hitos y entregables.</p>
       <p class="mt-1 text-xs text-slate-400">Activa un proyecto para comenzar a registrar avances y recibir feedback.</p>
@@ -11,7 +11,7 @@
       $milestonesCount = is_array($projectMilestones) ? count($projectMilestones) : 0;
       $projectStatusClasses = trim('inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold shadow-sm ring-1 ring-inset ring-black/5 dark:ring-white/10 ' . (status_badge_classes($selectedProject['status']) ?? 'bg-slate-200 text-slate-600'));
     ?>
-    <article class="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-xl shadow-indigo-100/50 transition dark:border-slate-800/70 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950/70 dark:shadow-none">
+    <article class="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-lg shadow-indigo-100/50 transition dark:border-slate-800/70 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950/70 dark:shadow-none">
       <div class="flex flex-col gap-6">
         <header class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div class="space-y-3">
@@ -56,7 +56,7 @@
 
         <div class="space-y-5">
           <?php if ($projectMilestones === []): ?>
-            <div class="rounded-2xl border border-dashed border-slate-300 bg-white/70 px-6 py-10 text-center text-sm text-slate-500 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+            <div class="rounded-2xl border border-dashed border-slate-300 bg-white/70 px-6 py-10 text-center text-sm text-slate-500 shadow-lg dark:border-slate-700 dark:bg-slate-900/60">
               <i data-lucide="sparkles" class="mx-auto mb-3 h-6 w-6 text-indigo-400"></i>
               <p class="font-medium text-slate-600 dark:text-slate-200">Aun no hay hitos registrados.</p>
               <p class="mt-1 text-xs text-slate-400">Crea el primer hito para planificar entregas y seguimiento.</p>
@@ -81,7 +81,7 @@
                 $milestoneStatusClasses = trim('inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-wide shadow-sm ring-1 ring-inset ring-black/5 dark:ring-white/10 ' . (status_badge_classes($milestone['status']) ?? 'bg-slate-200 text-slate-600'));
                 $milestoneDeliverablesCount = (int) ($milestone['deliverables_count'] ?? count($deliverables));
               ?>
-              <article id="milestone-<?= e((string) $milestone['id']); ?>" class="group relative overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/70 dark:bg-slate-900/60 dark:shadow-none">
+              <article id="milestone-<?= e((string) $milestone['id']); ?>" class="group relative overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-lg shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/70 dark:bg-slate-900/60 dark:shadow-none">
                 <div class="flex flex-col gap-5">
                   <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                     <div class="space-y-3"><h4 class="text-base font-semibold text-slate-800 dark:text-slate-100"><?= e($milestone['title']); ?></h4>
@@ -150,7 +150,7 @@
                   </div>
 
                   <div class="grid gap-4 lg:grid-cols-2">
-                    <section class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 text-xs shadow-inner shadow-slate-200/40 dark:border-slate-800/60 dark:bg-slate-900/60">
+                    <section class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 text-xs shadow-lg shadow-slate-200/50 dark:border-slate-800/60 dark:bg-slate-900/60">
                       <div class="flex items-center justify-between">
                         <p class="font-semibold text-slate-700 dark:text-slate-200">Entregables</p>
                         <span class="inline-flex items-center gap-1 rounded-full border border-indigo-200/70 bg-indigo-50 px-2.5 py-0.5 text-[11px] font-semibold text-indigo-700 shadow-sm dark:border-indigo-900/60 dark:bg-indigo-950/40 dark:text-indigo-200">
@@ -204,7 +204,7 @@
                       </div>
                     </section>
 
-                    <section class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 text-xs shadow-inner shadow-slate-200/40 dark:border-slate-800/60 dark:bg-slate-900/60">
+                    <section class="rounded-2xl border border-slate-200/60 bg-white/80 p-5 text-xs shadow-lg shadow-slate-200/50 dark:border-slate-800/60 dark:bg-slate-900/60">
                       <div class="flex items-center justify-between">
                         <p class="font-semibold text-slate-700 dark:text-slate-200">Feedback</p>
                         <span class="inline-flex items-center gap-1 rounded-full border border-emerald-200/70 bg-emerald-50 px-2.5 py-0.5 text-[11px] font-semibold text-emerald-700 shadow-sm dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-200">

--- a/app/Views/dashboard/components/sections/progress.php
+++ b/app/Views/dashboard/components/sections/progress.php
@@ -13,7 +13,7 @@ foreach ($boardMap as $columnKey => $_columnLabel) {
 }
 ?>
 <section id="section-progreso" data-section="progreso" class="space-y-8<?= $isProgressActive ? '' : ' hidden'; ?>">
-  <article class="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-xl shadow-indigo-100/50 transition dark:border-slate-800/70 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950/70 dark:shadow-none">
+  <article class="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-lg shadow-indigo-100/50 transition dark:border-slate-800/70 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950/70 dark:shadow-none">
     <div class="flex flex-col gap-6">
       <header class="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-300">
         <span class="inline-flex items-center gap-2 rounded-full border border-indigo-200/70 bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 shadow-sm dark:border-indigo-900/60 dark:bg-indigo-950/50 dark:text-indigo-200">
@@ -29,7 +29,7 @@ foreach ($boardMap as $columnKey => $_columnLabel) {
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         <?php foreach ($boardMap as $columnKey => $columnLabel): ?>
           <?php $items = $boardColumnsList[$columnKey] ?? []; ?>
-          <article class="flex h-full flex-col rounded-2xl border border-slate-200/60 bg-white/80 p-5 text-xs shadow-md shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
+          <article class="flex h-full flex-col rounded-2xl border border-slate-200/60 bg-white/80 p-5 text-xs shadow-lg shadow-slate-200/60 transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-xl dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-none">
             <div class="flex items-center justify-between">
               <div class="flex items-center gap-2 text-sm font-semibold text-slate-700 dark:text-slate-200">
                 <i data-lucide="diamond" class="h-3.5 w-3.5 text-indigo-400"></i>

--- a/app/Views/dashboard/components/sections/projects.php
+++ b/app/Views/dashboard/components/sections/projects.php
@@ -6,7 +6,7 @@ $selectedProjectId = (int) ($selectedProject['id'] ?? 0);
 $selectedProjectTitle = $selectedProject['title'] ?? null;
 ?>
 <section id="section-proyectos" data-section="proyectos" class="space-y-8<?= $isProjectsActive ? '' : ' hidden'; ?>">
-  <article class="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-xl shadow-indigo-100/50 transition dark:border-slate-800/70 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950/70 dark:shadow-none">
+  <article class="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-lg shadow-indigo-100/50 transition dark:border-slate-800/70 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950/70 dark:shadow-none">
     <div class="flex flex-col gap-6">
       <header class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-300">
@@ -34,7 +34,7 @@ $selectedProjectTitle = $selectedProject['title'] ?? null;
         </div>
       </header>
 
-      <div class="rounded-2xl border border-slate-200/70 bg-white/80 shadow-md shadow-slate-200/60 dark:border-slate-800/70 dark:bg-slate-900/70">
+      <div class="rounded-2xl border border-slate-200/70 bg-white/80 shadow-lg shadow-slate-200/60 dark:border-slate-800/70 dark:bg-slate-900/70">
         <?php if ($projectsList === []): ?>
           <div class="flex flex-col items-center gap-2 px-6 py-10 text-center text-sm text-slate-500">
             <i data-lucide="sparkles" class="h-5 w-5 text-indigo-400"></i>
@@ -157,7 +157,7 @@ $selectedProjectTitle = $selectedProject['title'] ?? null;
                 $isProjectSelected = $selectedProjectId !== 0 && $selectedProjectId === (int) $project['id'];
                 $statusChipClasses = trim('inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-wide shadow-sm ring-1 ring-inset ring-black/5 dark:ring-white/10 ' . (status_badge_classes($project['status']) ?? 'bg-slate-200 text-slate-600'));
               ?>
-              <article id="project-<?= e((string) $project['id']); ?>" class="space-y-4 rounded-2xl border border-slate-200/70 bg-white/90 p-4 shadow-sm shadow-slate-200/60 dark:border-slate-800/70 dark:bg-slate-900/80">
+              <article id="project-<?= e((string) $project['id']); ?>" class="space-y-4 rounded-2xl border border-slate-200/70 bg-white/90 p-4 shadow-lg shadow-slate-200/60 dark:border-slate-800/70 dark:bg-slate-900/80">
                 <div class="space-y-1">
                   <div class="flex items-start justify-between gap-3">
                     <div>


### PR DESCRIPTION
## Summary
- align dashboard sections, panels, and modals with a consistent shadow style for a cohesive visual hierarchy
- add explicit asterisk markers (with accessible text) to labels of required fields in dashboard modals and auth forms

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2cdcc4c8c832e882923eaadf58923