### PR TITLE
Add server-sent events for dashboard notifications

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -20,6 +20,7 @@ $router = new Router();
 $router->get('/', [AuthController::class, 'show']);
 $router->get('/dashboard', [DashboardController::class, 'index']);
 $router->get('/notifications', [NotificationsController::class, 'index']);
+$router->get('/notifications/stream', [NotificationsController::class, 'stream']);
 $router->get('/search', [SearchController::class, 'index']);
 $router->get('/projects', static function (): void {
     redirect_to('/dashboard?tab=proyectos');


### PR DESCRIPTION
## Summary
- add an authenticated `/notifications/stream` server-sent events endpoint that pushes snapshots, real-time items, and heartbeats
- extend the notification model with a streaming helper to read incremental rows
- hook the dashboard notifications panel to an `EventSource` client that keeps counts and lists in sync

## Testing
- php -l app/Controllers/NotificationsController.php
- php -l app/Models/Notification.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e315d2fe68832e836d93eb6e3e0106