### PR TITLE
Fix project selection precedence in dashboard

### DIFF
--- a/app/Controllers/DashboardController.php
+++ b/app/Controllers/DashboardController.php
@@ -54,11 +54,15 @@ class DashboardController extends Controller
         $requestedTab = $_GET['tab'] ?? null;
         $activeTabCandidate = Session::flash('dashboard_tab') ?? $requestedTab ?? 'dashboard';
 
-        $selectedProjectCandidate = Session::flash('dashboard_project_id');
-        if ($selectedProjectCandidate === null) {
-            $selectedProjectCandidate = (int) ($_GET['project'] ?? 0);
+        $requestedProjectId = isset($_GET['project']) ? (int) $_GET['project'] : 0;
+        $flashedProjectId = Session::flash('dashboard_project_id');
+        $flashedProjectId = $flashedProjectId !== null ? (int) $flashedProjectId : null;
+        if ($requestedProjectId > 0) {
+            $selectedProjectCandidate = $requestedProjectId;
+        } elseif ($flashedProjectId !== null) {
+            $selectedProjectCandidate = max(0, $flashedProjectId);
         } else {
-            $selectedProjectCandidate = (int) $selectedProjectCandidate;
+            $selectedProjectCandidate = 0;
         }
 
         $dashboardData = $this->buildDashboardData($user, [


### PR DESCRIPTION
## Summary
- make the dashboard prefer the project provided in the query string over any flashed value when selecting the active project

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7529b9d30832e8122ddcb10864469